### PR TITLE
Add http snippet setting for Instana

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.11.1]
+
+### Added
+
+- Added a new configmap configuration to the chart for being able to add a [http snippet](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#http-snippet). 
+
 ## [0.11.0]
 
 ### Added

--- a/helm/nginx-ingress-controller-app/Chart.yaml
+++ b/helm/nginx-ingress-controller-app/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.25.1
 description: A Helm chart for the nginx ingress-controller
 name: nginx-ingress-controller-app
-version: 0.11.0-[[ .SHA ]]
+version: 0.11.1-[[ .SHA ]]

--- a/helm/nginx-ingress-controller-app/templates/configmap.yaml
+++ b/helm/nginx-ingress-controller-app/templates/configmap.yaml
@@ -18,6 +18,10 @@ data:
   # See https://github.com/kubernetes/ingress-nginx/issues/549#issuecomment-291894246
   hsts: "{{ .Values.configmap.hsts }}"
 
+  {{- if index .Values.configmap "http-snippet" }}
+  http-snippet: {{ index .Values.configmap "http-snippet" }}
+  {{- end}}
+
   {{- if index .Values.configmap "large-client-header-buffers" }}
   large-client-header-buffers: "{{ index .Values.configmap "large-client-header-buffers" }}"
   {{- end}}

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -19,6 +19,7 @@ configmap:
 
   # optional settings that can be set.
   enable-underscores-in-headers: ""
+  http-snippet: ""
   large-client-header-buffers: ""
   log-format-upstream: ""
   proxy-buffers-size: ""


### PR DESCRIPTION
Instana needs to use the old port to get the stats. Adding the `http-snippet` to the configmap allows our customer to add it back