### PR TITLE
Sync back from legacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,30 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.12.0]
+## [1.0.0]
 
 ### Changed
 
 - Migrate to managed application structure.
 
-## [0.11.2]
-
-### Changed
-
-- Add option for setting `http2-max-field-size` via values.yaml.
-- Add optional http snippet parameter to extend nginx http configuration.
-
-## [0.11.1]
-
-### Added
-
-- Added a new configmap configuration to the chart for being able to add a [http snippet](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#http-snippet). 
-
-## [0.11.0]
-
-### Added
-
-- Migrate chart into [nginx-ingress-controller-app](https://github.com/giantswarm/nginx-ingress-controller-app) repository as managed application. 
 
 [kubernetes-nginx-ingress-controller](https://github.com/giantswarm/kubernetes-nginx-ingress-controller) repository is deprecated.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.0.0]
+## [1.1.0]
 
 ### Changed
 

--- a/helm/nginx-ingress-controller-app/Chart.yaml
+++ b/helm/nginx-ingress-controller-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v0.25.1
+appVersion: v0.26.1
 description: A Helm chart for the nginx ingress-controller
 home: https://github.com/giantswarm/nginx-ingress-controller-app
 name: nginx-ingress-controller-app

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -64,7 +64,7 @@ controller:
 
   image:
     repository: giantswarm/nginx-ingress-controller
-    tag: 0.25.1
+    tag: 0.26.1
 
   rbac:
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4795

I've checked all the PRs starting from `-app` repo creation data to sync all changes back. The only one is version. Also updating changelog with the `1.1.0` version, which I'll use for an app release tag.

I'll not tag it until we're ready to App CR migration