### PR TITLE
Remove unused default backend configuration

### DIFF
--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -97,28 +97,6 @@ controller:
   userID: 33
   groupID: 33
 
-defaultBackend:
-  name: default-http-backend
-  k8sAppLabel: default-http-backend
-  port: 8080
-
-  replicas: 2
-
-  image:
-    repository: giantswarm/defaultbackend
-    tag: 1.2
-
-  resources:
-    limits:
-      cpu: 10m
-      memory: 20Mi
-    requests:
-      cpu: 10m
-      memory: 20Mi
-
-  userID: 33
-  groupID: 33
-
 image:
   registry: quay.io
 


### PR DESCRIPTION
These settings seem to have been copied from now deprecated https://github.com/giantswarm/kubernetes-nginx-ingress-controller but they do not seem to be used anywhere.

Uncovered this while working on https://github.com/giantswarm/giantswarm/issues/6817