### PR TITLE
Add proxy protocol option in the service annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [v1.2.1] 2020-01-30
+
+### Changed
+
+- Support proxy protocol for AWS. ([#23](https://github.com/giantswarm/nginx-ingress-controller-app/pull/23))
+
 ## [v1.2.0] 2020-01-21
 
 ### Changed

--- a/helm/nginx-ingress-controller-app/templates/controller-service-aws-loadbalancer.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-aws-loadbalancer.yaml
@@ -8,6 +8,9 @@ metadata:
     {{ if eq .Values.controller.service.type "internal" }}
     service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
     {{ end }}
+    {{ if index .Values.configmap "use-proxy-protocol" }}
+    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: ‘*’
+    {{ end }}
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
   name: {{ .Values.controller.name }}
   namespace: {{ .Release.Namespace }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service-aws-loadbalancer.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-aws-loadbalancer.yaml
@@ -9,7 +9,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
     {{ end }}
     {{ if index .Values.configmap "use-proxy-protocol" }}
-    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: ‘*’
+    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
     {{ end }}
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
   name: {{ .Values.controller.name }}


### PR DESCRIPTION
We offer the option to setup the proxy protocol but to make it work we need to add the annotation in the Kubernetes service of the IC to tell AWS to create the ELB policy that forwards correctly the requests.