### PR TITLE
Enable NodePort Service just for legacy Azure tenant clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v1.5.0] 2020-02-18
+
+### Changed
+
+- Disable nginx NodePort Service by default, having legacy cluster-operator enable it for legacy Azure only. ([#28](https://github.com/giantswarm/nginx-ingress-controller-app/pull/28))
+
 ## [v1.4.0] 2020-02-10
 
 ### Changed
@@ -48,6 +54,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 Previous versions changelog can be found [here](https://github.com/giantswarm/kubernetes-nginx-ingress-controller/blob/master/CHANGELOG.md)
 
+[v1.5.0]: https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.5.0
 [v1.4.0]: https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.4.0
 [v1.3.0]: https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.3.0
 [v1.2.1]: https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.2.1

--- a/helm/nginx-ingress-controller-app/Configuration.md
+++ b/helm/nginx-ingress-controller-app/Configuration.md
@@ -30,6 +30,6 @@ Parameter | Description | Default
 `controller.metrics.enabled` | If true, create metrics Service for prometheus-operator support. | `false`
 `controller.metrics.port` | Configures container metrics port to be exposed. | `10254`
 `controller.metrics.service.servicePort` | Configures metrics Service port. | `9913`
-`controller.service.enabled` | If true, create NodePort service. Applies only to legacy clusters. | `true`
+`controller.service.enabled` | If true, create NodePort Service. Dynamically calculated during cluster creation. | `false`
 `controller.service.type` | Applies only to `provider=aws` (`external`/`internal`) | `external`
 `provider` | Provider identifier (`aws`/`azure`/`kvm`) | `kvm`

--- a/helm/nginx-ingress-controller-app/templates/controller-service-nodeport.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-nodeport.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.controller.service.enabled }}
-{{- if .Values.ingressController.legacy }}
-
 apiVersion: v1
 kind: Service
 metadata:
@@ -29,5 +27,4 @@ spec:
     targetPort: 443
   selector:
     k8s-app: {{ .Values.controller.k8sAppLabel }}
-{{-  end }}
 {{-  end }}

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -49,7 +49,7 @@ controller:
     name: nginx-ingress-role
 
   service:
-    enabled: true
+    enabled: false
     # type applies only to AWS provider:
     # - external (default)
     # - internal

--- a/integration/templates/ingress_controller_values.go
+++ b/integration/templates/ingress_controller_values.go
@@ -2,8 +2,8 @@
 
 package templates
 
-// IngressControllerValues sets legacy to true so the controller service uses
-// node ports.
-const IngressControllerValues = `ingressController:
-  legacy: true
+// IngressControllerValues defines value overrides to use in e2e test.
+const IngressControllerValues = `controller:
+  service:
+    enabled: true
 `


### PR DESCRIPTION
While testing legacy AWS WIP release https://github.com/giantswarm/releases/pull/88 a regression (introduced via https://github.com/giantswarm/nginx-ingress-controller-app/pull/12) was observed - nginx NodePort Service installation is being attempted as part of installing App chart, even though for legacy aws (and kvm) clusters one such service gets already created via ignition.

This PR simplifies NodePort Service template in nginx IC App - service enabled flag is disabled by default, and it gets flipped on only for legacy Azure by legacy cluster-operator (see https://github.com/giantswarm/cluster-operator/blob/legacy/service/controller/resource/clusterconfigmap/desired.go#L62-L74)

For aws node pool clusters LoadBalancer Service continues to be installed as before.

In this PR I've bumped minor version of nginx IC App to 1.5.0 as I plan to include, via another followup PR, in same release also upgrade to upstream nginx 0.29.0 to as a mitigation for https://github.com/giantswarm/giantswarm/issues/8707 (certificate validation resiliency was improved in latest go releases, and latest nginx is being built with latest go - see upstream issue https://github.com/kubernetes/ingress-nginx/issues/4828#issuecomment-581614267 and changelog https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md)

Plan is then to include both changes in legacy WIP releases which are among other things currently waiting for this regression fix:
- AWS 9.1.1 https://github.com/giantswarm/releases/pull/88
- KVM 11.1.1 https://github.com/giantswarm/releases/pull/89
- Azure 11.2.0 https://github.com/giantswarm/releases/pull/84