### PR TITLE
Upgrade to nginx-ingress-controller 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Disable nginx NodePort Service by default, having legacy cluster-operator enable it for legacy Azure only. ([#28](https://github.com/giantswarm/nginx-ingress-controller-app/pull/28))
+- Disable nginx NodePort Service by default, having legacy cluster-operator enable it for legacy Azure only. ([#29](https://github.com/giantswarm/nginx-ingress-controller-app/pull/29))
+- Upgrade to nginx-ingress-controller 0.29.0. ([#30](https://github.com/giantswarm/nginx-ingress-controller-app/pull/30))
 
 ## [v1.4.0] 2020-02-10
 

--- a/helm/nginx-ingress-controller-app/Chart.yaml
+++ b/helm/nginx-ingress-controller-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v0.28.0
+appVersion: v0.29.0
 description: A Helm chart for the nginx ingress-controller
 home: https://github.com/giantswarm/nginx-ingress-controller-app
 name: nginx-ingress-controller-app

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -41,7 +41,7 @@ controller:
   image:
     repository: giantswarm/nginx-ingress-controller
     # when updating tag make sure to also keep appVersion in Chart.yaml in sync
-    tag: 0.28.0
+    tag: 0.29.0
 
   rbac:
 


### PR DESCRIPTION
nginx IC 0.29.0 was updated from 1.13.1 to most recent go 1.13.8 which among other things includes fixes hardening certificate validation in go's crypto/x509 package (done in Go 1.13.7), which should help nginx IC panic less i.e. better handle (survive) invalid certificates customers configure as in https://github.com/giantswarm/giantswarm/issues/8707

For complete nginx IC 0.29.0 change log see https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0290
Go 1.13 release notes can be found at https://golang.org/doc/devel/release.html#go1.13

Plan is to release this as 1.5.0 and include it in legacy WIP releases:
- AWS 9.1.1 giantswarm/releases#88
- KVM 11.1.1 giantswarm/releases#89
- Azure 11.2.0 giantswarm/releases#84