### PR TITLE
Release 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [v1.6.1] 2020-03-10
 
 ### Changed
 
@@ -84,6 +84,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 Previous versions changelog can be found [here](https://github.com/giantswarm/kubernetes-nginx-ingress-controller/blob/master/CHANGELOG.md)
 
+[v1.6.1]: https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.6.1
 [v1.6.0]: https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.6.0
 [v1.5.0]: https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.5.0
 [v1.4.0]: https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.4.0


### PR DESCRIPTION
This release includes:
- Disabling HPA and clearing resource requests for XS clusters https://github.com/giantswarm/nginx-ingress-controller-app/pull/34

This nginx IC App release is to be included in
- AWS 9.0.1
- AWS 9.2.1
- KVM 11.2.1
- Azure 11.2.1
together with cluster-operator 0.23.5 https://github.com/giantswarm/cluster-operator/pull/959