### PR TITLE
Reintroduce prematurely dropped deprecated config properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Reintroduced config properties which should have been just deprecated but got dropped prematurely in v1.4.0 ([#35](https://github.com/giantswarm/nginx-ingress-controller-app/pull/35))
+  - `configmap.annotations-prefix`
+  - `configmap.default-ssl-certificate`
+  - `configmap.hpa-enabled`
+  - `configmap.hpa-max-replicas`
+  - `configmap.hpa-min-replicas`
+  - `configmap.hpa-target-cpu-utilization-percentage`
+  - `configmap.hpa-target-memory-utilization-percentage`
+  - `configmap.ingress-class`
+
 ## [v1.6.1] 2020-03-10
 
 ### Changed

--- a/helm/nginx-ingress-controller-app/Configuration.md
+++ b/helm/nginx-ingress-controller-app/Configuration.md
@@ -12,21 +12,29 @@ Parameter | Description | Default
 `clusterID` | Cluster ID. Dynamically calculated during cluster creation. Manual change doesn't affect this value | 'uun5a'
 `cluster.profile` | Cluster usage profile. Dynamically calculated during cluster creation. Supported values are `1` for extra small, and currently any value higher than 1 when actual cluster profile is unknown. HPA and PDB are disabled, and resource requests unset for extra small clusters. | `2`
 `configmap` | Sets the nginx configmap configuration overrides. | See official docs for nginx [configmap configuration options](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#configuration-options) and their defaults. Built-in overrides are covered below.
+`configmap.annotations-prefix` | This configuration property is deprecated and will be removed in the future, please migrate to `controller.annotationsPrefix`. | not configured by default
+`configmap.default-ssl-certificate` | This configuration property is deprecated and will be removed in the future, please migrate to `controller.defaultSSLCertificate`. | not configured by default
+`configmap.hpa-enabled` | This configuration property is deprecated and will be removed in the future, please migrate to `controller.autoscaling.enabled`. | not configured by default
+`configmap.hpa-max-replicas` | This configuration property is deprecated and will be removed in the future, please migrate to `controller.autoscaling.maxReplicas`. | not configured by default
+`configmap.hpa-min-replicas` | This configuration property is deprecated and will be removed in the future, please migrate to `controller.autoscaling.minReplicas`. | not configured by default
+`configmap.hpa-target-cpu-utilization-percentage` | This configuration property is deprecated and will be removed in the future, please migrate to `controller.autoscaling.targetCPUUtilizationPercentage`. | not configured by default
+`configmap.hpa-target-memory-utilization-percentage` | This configuration property is deprecated and will be removed in the future, please migrate to `controller.autoscaling.targetMemoryUtilizationPercentage`. | not configured by default
+`configmap.ingress-class` | This configuration property is deprecated and will be removed in the future, please migrate to `controller.ingressClass`. | not configured by default
 `configmap.error-log-level` | Configures the logging level of errors. | "error"
 `configmap.hsts` | Enables or disables the HTTP Strict Transport Security (HSTS) header in servers running SSL. | "false"
 `configmap.server-name-hash-bucket-size` | Sets the size of the bucket for the server names hash tables. | "1024"
 `configmap.server-tokens` | Controlls whether to send NGINX Server header in responses and display NGINX version in error pages. | "false"
 `configmap.worker-processes` | Sets the number of worker processes. | "1"
 `configmap.use-forwarded-headers` | If true, NGINX passes the incoming `X-Forwarded-*` headers to upstreams. | "true"
-`controller.annotationsPrefix` | Prefix of the Ingress annotations specific to the NGINX controller. | `nginx.ingress.kubernetes.io`
-`controller.autoscaling.enabled` | Enables or disables Horizontal Pod Autoscaler (HPA) for NGINX Ingress Controller Deployment. | `true`
-`controller.autoscaling.minReplicas` | Configures HPA min replicas. | `2`
-`controller.autoscaling.maxReplicas` | Configures HPA max replicas. | `20`
-`controller.autoscaling.targetCPUUtilizationPercentage` | Configures HPA target CPU utilization percentage. | `50`
-`controller.autoscaling.targetMemoryUtilizationPercentage` | Configures HPA target memory utilization percentage. | `50`
-`controller.defaultSSLCertificate` | The Secret referred to by this flag contains the default certificate to be used when accessing the catch-all server. If this flag is not provided NGINX will use a self-signed certificate. Example value: "default/foo-tls" | ""
+`controller.annotationsPrefix` | Prefix of the Ingress annotations specific to the NGINX controller. This is a replacement for deprecated `configmap.annotations-prefix` configuration property; if both are configured, `configmap.annotations-prefix` has precedence. | `nginx.ingress.kubernetes.io`
+`controller.autoscaling.enabled` | Enables or disables Horizontal Pod Autoscaler (HPA) for NGINX Ingress Controller Deployment. This is a replacement for deprecated `configmap.hpa-enabled` configuration property; if both are configured, `configmap.hpa-enabled` has precedence. | `true`
+`controller.autoscaling.maxReplicas` | Configures HPA max replicas. This is a replacement for deprecated `configmap.hpa-max-replicas` configuration property; if both are configured, `configmap.hpa-max-replicas` has precedence. | `20`
+`controller.autoscaling.minReplicas` | Configures HPA min replicas. This is a replacement for deprecated `configmap.hpa-min-replicas` configuration property; if both are configured, `configmap.hpa-min-replicas` has precedence. | `2`
+`controller.autoscaling.targetCPUUtilizationPercentage` | Configures HPA target CPU utilization percentage. This is a replacement for deprecated `configmap.hpa-target-cpu-utilization-percentage` configuration property; if both are configured, `configmap.hpa-target-cpu-utilization-percentage` has precedence. | `50`
+`controller.autoscaling.targetMemoryUtilizationPercentage` | Configures HPA target memory utilization percentage. This is a replacement for deprecated `configmap.hpa-target-memory-utilization-percentage` configuration property; if both are configured, `configmap.hpa-target-memory-utilization-percentage` has precedence. | `50`
+`controller.defaultSSLCertificate` | The Secret referred to by this flag contains the default certificate to be used when accessing the catch-all server. If this flag is not provided NGINX will use a self-signed certificate. Example value: "default/foo-tls". This is a replacement for deprecated `configmap.default-ssl-certificate` configuration property; if both are configured, `configmap.default-ssl-certificate` has precedence. | ""
 `controller.ingressController.legacy` | Legacy or node pools cluster. On aws provider node pool clusters LoadBalancer service gets created. Dynamically calculated during cluster creation. | `false`
-`controller.ingressClass` | Ingress class, which controller processes | `nginx`
+`controller.ingressClass` | Ingress class, which controller handles. This is a replacement for deprecated `configmap.ingress-class` configuration property; if both are configured, `configmap.ingress-class` has precedence. | `nginx`
 `controller.metrics.enabled` | If true, create metrics Service for prometheus-operator support. | `false`
 `controller.metrics.port` | Configures container metrics port to be exposed. | `10254`
 `controller.metrics.service.servicePort` | Configures metrics Service port. | `9913`

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -51,13 +51,23 @@ spec:
         args:
         - /nginx-ingress-controller
         - --configmap=$(POD_NAMESPACE)/{{ .Values.controller.configmap.name }}
+        {{- if index .Values.configmap "annotations-prefix" }}
+        - --annotations-prefix={{ index .Values.configmap "annotations-prefix" }}
+        {{- else if .Values.controller.annotationsPrefix }}
         - --annotations-prefix={{ .Values.controller.annotationsPrefix }}
-        {{- if .Values.controller.defaultSSLCertificate }}
+        {{- end}}
+        {{- if index .Values.configmap "default-ssl-certificate" }}
+        - --default-ssl-certificate={{ index .Values.configmap "default-ssl-certificate" }}
+        {{- else if .Values.controller.defaultSSLCertificate }}
         - --default-ssl-certificate={{ .Values.controller.defaultSSLCertificate }}
         {{- end}}
         - --enable-ssl-chain-completion=false
         - --enable-dynamic-certificates=true
+        {{- if index .Values.configmap "ingress-class" }}
+        - --ingress-class={{ index .Values.configmap "ingress-class" }}
+        {{- else if .Values.controller.ingressClass }}
         - --ingress-class={{ .Values.controller.ingressClass }}
+        {{- end}}
         {{- if not .Values.ingressController.legacy }}
         - --publish-service={{ .Release.Namespace }}/{{ .Values.controller.name }}
         {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/controller-hpa.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-hpa.yaml
@@ -1,5 +1,49 @@
 {{- if gt (.Values.cluster.profile | int) 1 }}
-{{- if .Values.controller.autoscaling.enabled }}
+{{- if index .Values.configmap "hpa-enabled" }}
+{{- if eq (index .Values.configmap "hpa-enabled") "true" }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Values.controller.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.controller.name }}
+    giantswarm.io/service-type: "managed"
+    k8s-app: {{ .Values.controller.k8sAppLabel }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.controller.name }}
+  {{- if index .Values.configmap "hpa-min-replicas" }}
+  minReplicas: {{ index .Values.configmap "hpa-min-replicas" }}
+  {{- else }}
+  minReplicas: {{ .Values.controller.autoscaling.minReplicas }}
+  {{- end }}
+  {{- if index .Values.configmap "hpa-max-replicas" }}
+  maxReplicas: {{ index .Values.configmap "hpa-max-replicas" }}
+  {{- else }}
+  maxReplicas: {{ .Values.controller.autoscaling.maxReplicas }}
+  {{- end }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        {{- if index .Values.configmap "hpa-target-cpu-utilization-percentage" }}
+        targetAverageUtilization: {{ index .Values.configmap "hpa-target-cpu-utilization-percentage" }}
+        {{- else }}
+        targetAverageUtilization: {{ .Values.controller.autoscaling.targetCPUUtilizationPercentage }}
+        {{- end }}
+    - type: Resource
+      resource:
+        name: memory
+        {{- if index .Values.configmap "hpa-target-memory-utilization-percentage" }}
+        targetAverageUtilization: {{ index .Values.configmap "hpa-target-memory-utilization-percentage" }}
+        {{- else }}
+        targetAverageUtilization: {{ .Values.controller.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- end }}
+{{- end}}
+{{- else if .Values.controller.autoscaling.enabled }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -17,17 +61,17 @@ spec:
   minReplicas: {{ .Values.controller.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.controller.autoscaling.maxReplicas }}
   metrics:
-{{- with .Values.controller.autoscaling.targetCPUUtilizationPercentage }}
+    {{- with .Values.controller.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
         targetAverageUtilization: {{ . }}
-{{- end }}
-{{- with .Values.controller.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- with .Values.controller.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
         targetAverageUtilization: {{ . }}
-{{- end }}
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/rbac.yaml
+++ b/helm/nginx-ingress-controller-app/templates/rbac.yaml
@@ -120,7 +120,11 @@ rules:
     # Here: "<ingress-controller-leader>-<nginx>"
     # This has to be adapted if you change either parameter
     # when launching the nginx-ingress-controller.
+  {{- if index .Values.configmap "ingress-class" }}
+  - "ingress-controller-leader-{{ index .Values.configmap "ingress-class" }}
+  {{- else if .Values.controller.ingressClass }}
   - "ingress-controller-leader-{{ .Values.controller.ingressClass }}"
+  {{- end}}
   verbs:
   - get
   - update


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/9379

These config properties were dropped in https://github.com/giantswarm/nginx-ingress-controller-app/pull/26, released in nginx IC App v1.4.0.