### PR TITLE
Release 1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [v1.6.3] 2020-03-16
 
 ### Changed
 
@@ -105,11 +105,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Migrate to managed application structure.
 
-
 [kubernetes-nginx-ingress-controller](https://github.com/giantswarm/kubernetes-nginx-ingress-controller) repository is deprecated.
 
 Previous versions changelog can be found [here](https://github.com/giantswarm/kubernetes-nginx-ingress-controller/blob/master/CHANGELOG.md)
 
+[v1.6.3]: https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.6.3
 [v1.6.2]: https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.6.2
 [v1.6.1]: https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.6.1
 [v1.6.0]: https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.6.0


### PR DESCRIPTION
This release includes:
- Differentiate resource requests and autoscaling for xxs, xs and s cluster profiles #38

This nginx IC App release is to be included in platform releases:
- AWS 9.0.1
- AWS 9.2.1
- KVM 11.2.1
- Azure 11.2.1
together with cluster-operator 0.23.6 https://github.com/giantswarm/cluster-operator/pull/975