### PR TITLE
Fix small cluster profile resource requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Fix small cluster profile resource requests. ([#42](https://github.com/giantswarm/nginx-ingress-controller-app/pull/42))
+
 ## [v1.6.4] 2020-03-17
 
 ### Changed
@@ -115,6 +121,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 Previous versions changelog can be found [here](https://github.com/giantswarm/kubernetes-nginx-ingress-controller/blob/master/CHANGELOG.md)
 
+[Unreleased]: https://github.com/giantswarm/nginx-ingress-controller-app/compare/v1.6.4...master
 [v1.6.4]: https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.6.4
 [v1.6.3]: https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.6.3
 [v1.6.2]: https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.6.2

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -97,7 +97,7 @@ spec:
         {{- if .Values.cluster.profile }}
         {{- if gt (.Values.cluster.profile | int) 2 }}
         resources:
-          {{- if eq (.Values.cluster.profile | quote) "3" }}
+          {{- if eq (.Values.cluster.profile | toString) "3" }}
 {{ toYaml .Values.controller.profile.small.resources | indent 10 }}
           {{- else }}
 {{ toYaml .Values.controller.resources | indent 10 }}

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -97,7 +97,7 @@ spec:
         {{- if .Values.cluster.profile }}
         {{- if gt (.Values.cluster.profile | int) 2 }}
         resources:
-          {{- if eq (.Values.cluster.profile | toString) "3" }}
+          {{- if eq (.Values.cluster.profile | int) 3 }}
 {{ toYaml .Values.controller.profile.small.resources | indent 10 }}
           {{- else }}
 {{ toYaml .Values.controller.resources | indent 10 }}

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -97,7 +97,7 @@ spec:
         {{- if .Values.cluster.profile }}
         {{- if gt (.Values.cluster.profile | int) 2 }}
         resources:
-          {{- if eq (.Values.cluster.profile | int) 3 }}
+          {{- if eq (.Values.cluster.profile | toString) "3" }}
 {{ toYaml .Values.controller.profile.small.resources | indent 10 }}
           {{- else }}
 {{ toYaml .Values.controller.resources | indent 10 }}

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -85,8 +85,9 @@ controller:
     # small (3) cluster profile - > 3 worker nodes, max CPU still < 4
     small:
       resources:
-        cpu: 500m
-        memory: 600Mi
+        requests:
+          cpu: 500m
+          memory: 600Mi
 
   # optional hpa settings
   autoscaling:

--- a/integration/templates/ingress_controller_values.go
+++ b/integration/templates/ingress_controller_values.go
@@ -3,11 +3,9 @@
 package templates
 
 // IngressControllerValues defines value overrides to use in e2e test.
-const IngressControllerValues = `controller:
-  resources:
-    requests:
-      cpu: 500m
-      memory: 600Mi
+const IngressControllerValues = `cluster:
+  profile: 3
+controller:
   service:
     enabled: true
 `


### PR DESCRIPTION
While testing [kvm 11.2.1 WIP release](https://github.com/giantswarm/releases/pull/139) it was uncovered that small cluster profile (encoded with 3) is not being handled correctly - desired resource requests were not being set. This PR fixes the issue.