### PR TITLE
Remove use of deprecated enable-dynamic-certificates CLI flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
+- Remove use of `enable-dynamic-certificates` CLI flag, it has been deprecated since [ingress-nginx 0.26.0](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0260) via [ingress-nginx PR #4356](https://github.com/kubernetes/ingress-nginx/pull/4356)
+
 ## [v1.6.7] 2020-04-08
 
 ### Changed

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -64,7 +64,6 @@ spec:
         - --default-ssl-certificate={{ .Values.controller.defaultSSLCertificate }}
         {{- end}}
         - --enable-ssl-chain-completion=false
-        - --enable-dynamic-certificates=true
         {{- if index .Values.configmap "ingress-class" }}
         - --ingress-class={{ index .Values.configmap "ingress-class" }}
         {{- else if .Values.controller.ingressClass }}


### PR DESCRIPTION
Dynamic mode is enabled by default and cannot be turned off, although option is still there but just to display deprecation warning.