### PR TITLE
Change default error-log-level from error to notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Remove use of `enable-dynamic-certificates` CLI flag, it has been deprecated since [ingress-nginx 0.26.0](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0260) via [ingress-nginx PR #4356](https://github.com/kubernetes/ingress-nginx/pull/4356)
-- Change default `error-log-level` from `error` to `notice`.
+- Removed use of `enable-dynamic-certificates` CLI flag, it has been deprecated since [ingress-nginx 0.26.0](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0260) via [ingress-nginx PR #4356](https://github.com/kubernetes/ingress-nginx/pull/4356)
+- Changed default `error-log-level` from `error` to `notice`.
 - Added a link to the README in the sources of Chart.yaml
 
 ## [v1.6.7] 2020-04-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Added a link to the README in the sources of Chart.yaml
 - Remove use of `enable-dynamic-certificates` CLI flag, it has been deprecated since [ingress-nginx 0.26.0](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0260) via [ingress-nginx PR #4356](https://github.com/kubernetes/ingress-nginx/pull/4356)
+- Change default `error-log-level` from `error` to `notice`.
+- Added a link to the README in the sources of Chart.yaml
 
 ## [v1.6.7] 2020-04-08
 

--- a/helm/nginx-ingress-controller-app/Configuration.md
+++ b/helm/nginx-ingress-controller-app/Configuration.md
@@ -20,7 +20,7 @@ Parameter | Description | Default
 `configmap.hpa-target-cpu-utilization-percentage` | This configuration property is deprecated and will be removed in the future, please migrate to `controller.autoscaling.targetCPUUtilizationPercentage`. | not configured by default
 `configmap.hpa-target-memory-utilization-percentage` | This configuration property is deprecated and will be removed in the future, please migrate to `controller.autoscaling.targetMemoryUtilizationPercentage`. | not configured by default
 `configmap.ingress-class` | This configuration property is deprecated and will be removed in the future, please migrate to `controller.ingressClass`. | not configured by default
-`configmap.error-log-level` | Configures the logging level of errors. | "error"
+`configmap.error-log-level` | Configures the logging level of errors. | "notice"
 `configmap.hsts` | Enables or disables the HTTP Strict Transport Security (HSTS) header in servers running SSL. | "false"
 `configmap.server-name-hash-bucket-size` | Sets the size of the bucket for the server names hash tables. | "1024"
 `configmap.server-tokens` | Controlls whether to send NGINX Server header in responses and display NGINX version in error pages. | "false"

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -22,7 +22,7 @@ ingressController:
 
 # for all the nginx configmap config options see https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#configmaps
 configmap:
-  error-log-level: "error"
+  error-log-level: "notice"
   # Disables setting a 'Strict-Transport-Security' header, which can be harmful.
   # See https://github.com/kubernetes/ingress-nginx/issues/549#issuecomment-291894246
   hsts: "false"


### PR DESCRIPTION
Upstream `error-log-level` defaults to `notice` (see https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#error-log-level) 
Our nginx IC chart had `error-log-level` default overridden to `error` via https://github.com/giantswarm/kubernetes-nginx-ingress-controller/pull/61 i.e. https://github.com/giantswarm/giantswarm/issues/2614 - @jgsqware if you remember please correct me if wrong - IIUC intention of that PR seems to have been to enable access and error logs, while overriding of `error-log-level` from upstream default `notice` to `error` was not really intended.

Anyway, for debugging incidents like:
- https://github.com/giantswarm/giantswarm/issues/9884
- https://github.com/giantswarm/giantswarm/issues/9706

it would help to have liveness/readiness probes errors in the error log and they are logged on `notice` log level, and I see no harm in having more logs from reducing log level from `error` to `notice`. With this change we'd be also aligned again with upstream default.

By the docs, nginx supports following log levels: `debug`, `info`, `notice`, `warn`, `error`, `crit`, `alert`, or `emerg`.