### PR TITLE
Prepare v1.6.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
+## [v1.6.8] 2020-04-09
+
+### Changed
+
 - Default `max-worker-connections` to `0`, making it same as `max-worker-open-files` i.e. `max open files (system's limit) / worker-processes - 1024`.
   This optimizes for high load conditions where it improves performance at the cost of increasing RAM utilization (even on idle).
 - HorizontalPodAutoscaler was tuned to use `targetMemoryUtilizationPercentage` of `80` due to increased RAM utilization with new default for `max-worker-connections` of `0`.
@@ -147,7 +151,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 Previous versions changelog can be found [here](https://github.com/giantswarm/kubernetes-nginx-ingress-controller/blob/master/CHANGELOG.md)
 
-[Unreleased]: https://github.com/giantswarm/nginx-ingress-controller-app/compare/v1.6.7...master
+[Unreleased]: https://github.com/giantswarm/nginx-ingress-controller-app/compare/v1.6.8...master
+[v1.6.8]: https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.6.8
 [v1.6.7]: https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.6.7
 [v1.6.6]: https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.6.6
 [v1.6.5]: https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.6.5


### PR DESCRIPTION
Includes:
- Default max-worker-connections to 0 (https://github.com/giantswarm/nginx-ingress-controller-app/pull/50)
- Change default error-log-level from error to notice (https://github.com/giantswarm/nginx-ingress-controller-app/pull/51)
- Remove use of deprecated enable-dynamic-certificates CLI flag (https://github.com/giantswarm/nginx-ingress-controller-app/pull/49)
- Add link to readme in sources (https://github.com/giantswarm/nginx-ingress-controller-app/pull/48)