### PR TITLE
Configure performance improving sysctls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
+- Configured NGINX IC container sysctls for performance improvements (see [ingress-nginx#1939](https://github.com/kubernetes/ingress-nginx/issues/1939)).
+
 ## [v1.6.8] 2020-04-09
 
 ### Changed

--- a/helm/nginx-ingress-controller-app/Configuration.md
+++ b/helm/nginx-ingress-controller-app/Configuration.md
@@ -47,5 +47,6 @@ Parameter | Description | Default
 `controller.replicaCount` | Number of initial NGINX IC Deployment replicas. | `1`
 `controller.service.enabled` | If true, create NodePort Service. Dynamically calculated during cluster creation. | `false`
 `controller.service.type` | Applies only to `provider=aws` (`external`/`internal`) | `external`
+`controller.sysctls` | Configures sysctls for the NGINX IC. | Performance improvements from https://github.com/kubernetes/ingress-nginx/issues/1939
 `controller.terminationGracePeriodSeconds` | Maximum amount of time NGINX Deployment replica is given to gracefully terminate. This should not be lower than `configmap.worker-shutdown-timeout`. | 300
 `provider` | Provider identifier (`aws`/`azure`/`kvm`) | `kvm`

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -81,6 +81,10 @@ spec:
               - NET_BIND_SERVICE
           runAsUser: {{ .Values.controller.userID }}
           runAsGroup: {{ .Values.controller.groupID }}
+          {{- if .Values.controller.sysctls }}
+          sysctls:
+            {{- toYaml .Values.controller.sysctls | nindent 12 }}
+          {{- end }}
         env:
         - name: POD_NAME
           valueFrom:

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -81,10 +81,6 @@ spec:
               - NET_BIND_SERVICE
           runAsUser: {{ .Values.controller.userID }}
           runAsGroup: {{ .Values.controller.groupID }}
-          {{- if .Values.controller.sysctls }}
-          sysctls:
-            {{- toYaml .Values.controller.sysctls | nindent 12 }}
-          {{- end }}
         env:
         - name: POD_NAME
           valueFrom:
@@ -130,3 +126,8 @@ spec:
           containerPort: {{ .Values.controller.metrics.port }}
           protocol: TCP
         {{- end }}
+      {{- if .Values.controller.sysctls }}
+      securityContext:
+        sysctls:
+          {{- toYaml .Values.controller.sysctls | nindent 12 }}
+      {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -129,5 +129,5 @@ spec:
       {{- if .Values.controller.sysctls }}
       securityContext:
         sysctls:
-          {{- toYaml .Values.controller.sysctls | nindent 12 }}
+        {{- toYaml .Values.controller.sysctls | nindent 8 }}
       {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/psp.yaml
+++ b/helm/nginx-ingress-controller-app/templates/psp.yaml
@@ -11,6 +11,8 @@ spec:
   privileged: false
   allowedCapabilities:
   - NET_BIND_SERVICE
+  allowedUnsafeSysctls:
+  - net.core.somaxconn
   runAsUser:
     rule: MustRunAsNonRoot
   seLinux:

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -128,7 +128,7 @@ controller:
     # Ingress controller performance improvements
     # See https://github.com/kubernetes/ingress-nginx/issues/1939
     - name: net.ipv4.ip_local_port_range
-      value: "'1024 65000'" # default '32768	60999', we set it on host to '1024 65535'
+      value: "1024 65000" # default '32768	60999', we set it on host to '1024 65535'
     - name: net.core.somaxconn # this is unsafe, has to be allowed on kubelet with https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubelet/config/v1beta1/types.go#L757
       value: "32768" # default 128, we set it on host to '32768'
 

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -124,6 +124,14 @@ controller:
   userID: 101
   groupID: 101
 
+  sysctls:
+    # Ingress controller performance improvements
+    # See https://github.com/kubernetes/ingress-nginx/issues/1939
+    - name: net.ipv4.ip_local_port_range
+      value: "'1024 65000'" # default '32768	60999', we set it on host to '1024 65535'
+    - name: net.core.somaxconn # this is unsafe, has to be allowed on kubelet with https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubelet/config/v1beta1/types.go#L757
+      value: "32768" # default 128, we set it on host to '32768'
+
 image:
   registry: quay.io
 


### PR DESCRIPTION
To improve nginx performance following is recommended https://github.com/kubernetes/ingress-nginx/issues/1939

It turned out we already had these optimizations introduced back in from beginning of kubernetes-nginx-ingress-controller, nginx-ingress-controller-app predecessor, https://github.com/giantswarm/kubernetes-nginx-ingress-controller/pull/2

With hardening across the stack done last year, this nginx IC perf improvements configuration (set initially through init container) got removed via https://github.com/giantswarm/kubernetes-nginx-ingress-controller/pull/94/files#diff-c83f79df1a69a7a302bc5c17c284f945L46 and moved to host OS kernel settings via https://github.com/giantswarm/k8scloudconfig/pull/537
It's still there https://github.com/giantswarm/k8scloudconfig/blob/master/v_6_0_0/files/conf/hardening.conf#L16-L19
even though this move was initially argued that it shouldn't be moved to host OS since it's nginx specific https://github.com/giantswarm/kubernetes-nginx-ingress-controller/pull/93/files#r282912501

Nevertheless, problem is that this move of perf improvements settings from nginx init container to host OS, actually broke it, these settings are not propagated from host OS to nginx Pod.

This PR reintroduces nginx perf improvement settings by applying https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/#setting-sysctls-for-a-pod

For this approach to actually work, this PR alone is not enough, kubelet has to be configured to allow `net.core.somaxconn` sysctl which is currently considered as unsafe. There was discussion and PR to add it to the safe sysctls list by default https://github.com/kubernetes/kubernetes/pull/54896#issuecomment-344541244 but it seems that, among other things, has cgroups v2 as dependency.