### PR TITLE
Mount host /proc to propagate nginx perf improvement settings

### DIFF
--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -127,12 +127,11 @@ spec:
           protocol: TCP
         {{- end }}
         volumeMounts:
-        # mount host /proc to get nginx perf improvement settings https://github.com/kubernetes/ingress-nginx/issues/1939 set on host propagated to nginx 
-        - mountPath: /proc
-          mountPropagation: HostToContainer
-          name: proc
-          readOnly: true
+        # mount host somaxconn to get nginx perf improvement settings https://github.com/kubernetes/ingress-nginx/issues/1939 set on host propagated to nginx 
+        - name: somaxconn
+          mountPath: /proc/sys/net/core/somaxconn
       volumes:
-      - hostPath:
-        path: /proc
-        name: proc
+      - name: somaxconn
+        hostPath:
+          path: /proc/sys/net/core/somaxconn
+          type: File

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -131,6 +131,7 @@ spec:
         - name: proc
           mountPath: /proc
           mountPropagation: Bidirectional
+          readOnly: true
       volumes:
       - name: proc
         hostPath:

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -126,3 +126,13 @@ spec:
           containerPort: {{ .Values.controller.metrics.port }}
           protocol: TCP
         {{- end }}
+        volumeMounts:
+        # mount host /proc to get nginx perf improvement settings https://github.com/kubernetes/ingress-nginx/issues/1939 set on host propagated to nginx 
+        - mountPath: /proc
+          mountPropagation: HostToContainer
+          name: proc
+          readOnly: true
+      volumes:
+      - hostPath:
+        path: /proc
+        name: proc

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -130,8 +130,6 @@ spec:
         # mount host /proc to get nginx perf improvement settings https://github.com/kubernetes/ingress-nginx/issues/1939 set on host propagated to nginx 
         - name: proc
           mountPath: /proc
-          mountPropagation: HostToContainer
-          readOnly: true
       volumes:
       - name: proc
         hostPath:

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -130,7 +130,7 @@ spec:
         # mount host /proc to get nginx perf improvement settings https://github.com/kubernetes/ingress-nginx/issues/1939 set on host propagated to nginx 
         - name: proc
           mountPath: /proc
-          readOnly: true
+          mountPropagation: HostToContainer
       volumes:
       - name: proc
         hostPath:

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -127,11 +127,12 @@ spec:
           protocol: TCP
         {{- end }}
         volumeMounts:
-        # mount host somaxconn to get nginx perf improvement settings https://github.com/kubernetes/ingress-nginx/issues/1939 set on host propagated to nginx 
-        - name: somaxconn
-          mountPath: /proc/sys/net/core/somaxconn
+        # mount host /proc to get nginx perf improvement settings https://github.com/kubernetes/ingress-nginx/issues/1939 set on host propagated to nginx 
+        - name: proc
+          mountPath: /proc
+          mountPropagation: HostToContainer
+          readOnly: true
       volumes:
-      - name: somaxconn
+      - name: proc
         hostPath:
-          path: /proc/sys/net/core/somaxconn
-          type: File
+          path: /proc

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -130,6 +130,7 @@ spec:
         # mount host /proc to get nginx perf improvement settings https://github.com/kubernetes/ingress-nginx/issues/1939 set on host propagated to nginx 
         - name: proc
           mountPath: /proc
+          readOnly: true
       volumes:
       - name: proc
         hostPath:

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -130,7 +130,7 @@ spec:
         # mount host /proc to get nginx perf improvement settings https://github.com/kubernetes/ingress-nginx/issues/1939 set on host propagated to nginx 
         - name: proc
           mountPath: /proc
-          mountPropagation: HostToContainer
+          mountPropagation: Bidirectional
       volumes:
       - name: proc
         hostPath:


### PR DESCRIPTION
This is an alternative approach to https://github.com/giantswarm/nginx-ingress-controller-app/pull/55 to have [nginx performance improvement settings](https://github.com/kubernetes/ingress-nginx/issues/1939) (which got moved from nginx init container https://github.com/giantswarm/kubernetes-nginx-ingress-controller/pull/94/files#diff-c83f79df1a69a7a302bc5c17c284f945L46 to host OS https://github.com/giantswarm/k8scloudconfig/pull/537) to be propagated to nginx Pod.