### PR TITLE
Use 2 replicas for integration test

### DIFF
--- a/integration/templates/ingress_controller_values.go
+++ b/integration/templates/ingress_controller_values.go
@@ -6,6 +6,7 @@ package templates
 const IngressControllerValues = `cluster:
   profile: 3
 controller:
+  replicaCount: 2
   service:
     enabled: true
 `


### PR DESCRIPTION
This stabilizes integration tests - they were running with 1 replica (default adjusted for smallest customer clusters) and only sometimes would scale out to 2 by HPA as exception.