### PR TITLE
Fix the readme url, it is tagged with a v

### DIFF
--- a/helm/nginx-ingress-controller-app/Chart.yaml
+++ b/helm/nginx-ingress-controller-app/Chart.yaml
@@ -7,4 +7,4 @@ name: nginx-ingress-controller-app
 namespace: kube-system
 version: [[ .Version ]]
 sources:
-  - https://raw.githubusercontent.com/giantswarm/nginx-ingress-controller-app/[[ .Version ]]/README.md
+  - https://raw.githubusercontent.com/giantswarm/nginx-ingress-controller-app/v[[ .Version ]]/README.md


### PR DESCRIPTION
I made a mistake in the Readme URL. Didn't notice that until I tried to open a tagged app as opposed to a test app. Since the test app has some special code that removes the version and uses just the sha.