### PR TITLE
Make monitoring headless Service non-optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Enable managed app monitoring.
+- Make monitoring headless Service non-optional.
+- Enable managed app monitoring via monitoring service.
 
 ## [v1.7.0] 2020-06-29
 

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -173,8 +173,6 @@ spec:
         - name: https
           containerPort: 443
           protocol: TCP
-        {{- if .Values.controller.metrics.enabled }}
         - name: metrics
           containerPort: {{ .Values.controller.metrics.port }}
           protocol: TCP
-        {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/controller-metrics-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-metrics-service.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     giantswarm.io/monitoring: "true"
     giantswarm.io/monitoring-path: /metrics
-    giantswarm.io/monitoring-port: {{ .Values.controller.metrics.service.servicePort | quote }}
+    giantswarm.io/monitoring-port: {{ .Values.controller.metrics.port | quote }}
   labels:
     app: {{ .Values.controller.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/nginx-ingress-controller-app/templates/controller-metrics-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-metrics-service.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.controller.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -7,7 +6,7 @@ metadata:
   annotations:
     giantswarm.io/monitoring: "true"
     giantswarm.io/monitoring-path: /metrics
-    giantswarm.io/monitoring-port: "2020"
+    giantswarm.io/monitoring-port: {{ .Values.controller.metrics.service.servicePort | quote }}
   labels:
     app: {{ .Values.controller.name }}
     giantswarm.io/service-type: "managed"
@@ -20,4 +19,3 @@ spec:
     targetPort: metrics
   selector:
     app.kubernetes.io/name: {{ .Values.controller.k8sAppLabel }}
-{{-  end }}

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -166,10 +166,6 @@ controller:
   # controller.metrics
   metrics:
 
-    # controller.metrics.enabled
-    # If true, create the metrics Service for prometheus-operator support.
-    enabled: true
-
     # controller.metrics.port
     # The port on which the metrics container is exposed.
     port: 10254


### PR DESCRIPTION
Towards giantswarm/giantswarm#10197

As follow up to https://github.com/giantswarm/nginx-ingress-controller-app/pull/84, this PR
- makes monitoring headless Service non-optional,
- fixes bug with hardcoded app monitoring port