### PR TITLE
Support separate internal LB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
+- Support additional Service, for internal traffic. Existing Service can still be configured to be either for public (default) or internal traffic.
 - Make monitoring headless Service non-optional.
 - Enable managed app monitoring via monitoring service.
 

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: ingress.{{ .Values.baseDomain }}
+    external-dns.alpha.kubernetes.io/hostname: ingress-internal.{{ .Values.baseDomain }}
   {{- if eq .Values.controller.service.internal.type "LoadBalancer" }}
   {{- if eq .Values.provider "aws" }}
     service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.controller.service.internal.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: ingress.{{ .Values.baseDomain }}
+  {{- if eq .Values.controller.service.internal.type "LoadBalancer" }}
+  {{- if eq .Values.provider "aws" }}
+    service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+    {{- if index .Values.configmap "use-proxy-protocol" }}
+    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
+    {{- end }}
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+  {{- else if eq .Values.provider "azure" }}
+    # this annotation adds lb rules for both TCP and UDP to allow UDP outbound connection with Standard LB
+    service.beta.kubernetes.io/azure-load-balancer-mixed-protocols: "true"
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+  {{- end }}
+  {{- end }}
+  name: {{ .Values.controller.name }}-internal
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.controller.name }}
+    giantswarm.io/service-type: "managed"
+    app.kubernetes.io/name: {{ .Values.controller.k8sAppLabel }}
+spec:
+  type: {{ .Values.controller.service.internal.type }}
+  {{- if eq .Values.controller.service.internal.type "LoadBalancer" }}
+  loadBalancerSourceRanges:
+  - 0.0.0.0/0
+  {{- end }}
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    app.kubernetes.io/name: {{ .Values.controller.k8sAppLabel }}
+  {{- if .Values.controller.service.internal.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.controller.service.internal.externalTrafficPolicy }}
+  {{- end }}
+{{- end }}

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -285,6 +285,23 @@ controller:
     # Valid values: LoadBalancer, NodePort
     type: LoadBalancer
 
+    # controller.service.internal
+    # Configuration settings for `-internal` suffixed Service variant.
+    # This second Service partially covers use case and need for multiple ingress controllers, providing separate IPs for public and internal traffic in single app.
+    internal:
+
+      # controller.service.internal.enabled
+      enabled: false
+
+      # controller.service.internal.type
+      type: LoadBalancer
+
+      # controller.service.internal.externalTrafficPolicy
+      # Configures kube-proxy, denotes if this Service desires to have external traffic routed to node-local or cluster-wide endpoints
+      #   Local - kube-proxy only proxies requests to local endpoints (does not forward traffic to other nodes), source IP preserved
+      #   Cluster - kube-proxy proxies requests randomly across all endpoints (forwards traffic to other nodes if necessary), source IP NAT'd
+      externalTrafficPolicy: "Local"
+
 # image
 image:
   registry: quay.io


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/9332

public/internal LB choice was supported for AWS node pools since beginning of the repo and 10.* platform releases https://github.com/giantswarm/nginx-ingress-controller-app/pull/4

public/internal LB choice was supported for Azure since 11.4.0 and nginx IC App 1.7.0 via https://github.com/giantswarm/nginx-ingress-controller-app/pull/73

Customers actually need both public and internal.

We do not yet support installing multiple nginx App per TC, multiple ingress classes so one can configure multiple Ingress resources per backend service, one for each kind of clients, i.e. https://github.com/giantswarm/giantswarm/issues/9060 is still TODO

This PR adds support for enabling additional nginx-ingress-controller-internal Service, optimized to be used as internal traffic LB, in single nginx App, with separate IP. It's aligned with similar feature added recently in upstream chart https://github.com/kubernetes/ingress-nginx/pull/5717.