### PR TITLE
Fix controller RBAC permissions for leader election ConfigMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Fixed
 
-- Fix RBAC permissions for the controller, allowing "get" and "update" locking leader election ConfigMap.
+- Fix controller RBAC permissions, granting "get" and "update" of leader election ConfigMap lock.
 
 ## [1.8.1] - 2020-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix RBAC permissions for controller, allow get and update locking leader election ConfigMap.
+
 ## [1.8.1] - 2020-07-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Fixed
 
-- Fix RBAC permissions for controller, allow get and update locking leader election ConfigMap.
+- Fix RBAC permissions for the controller, allowing "get" and "update" locking leader election ConfigMap.
 
 ## [1.8.1] - 2020-07-28
 

--- a/helm/nginx-ingress-controller-app/templates/rbac.yaml
+++ b/helm/nginx-ingress-controller-app/templates/rbac.yaml
@@ -63,6 +63,15 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - {{ include "resource.default.name" . }}-{{ .Values.controller.ingressClass }}
+  verbs:
+  - get
+  - update
+- apiGroups:
   - extensions
   - networking.k8s.io
   resources:

--- a/helm/nginx-ingress-controller-app/templates/rbac.yaml
+++ b/helm/nginx-ingress-controller-app/templates/rbac.yaml
@@ -63,15 +63,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - configmaps
-  resourceNames:
-  - {{ include "resource.default.name" . }}-{{ .Values.controller.ingressClass }}
-  verbs:
-  - get
-  - update
-- apiGroups:
   - extensions
   - networking.k8s.io
   resources:
@@ -122,7 +113,7 @@ rules:
     # This has to be adapted if you change either parameter
     # when launching the nginx-ingress-controller.
   {{- if .Values.controller.ingressClass }}
-  - "ingress-controller-leader-{{ .Values.controller.ingressClass }}"
+  - "{{ include "resource.default.name" . }}-{{ .Values.controller.ingressClass }}"
   {{- end}}
   verbs:
   - get


### PR DESCRIPTION
This was broken with multi-nginx support.

Previously hardcoded/default election ID was since then made dynamic (for multi-nginx support), based on App i.e. helm release name, while RBAC permission/rule wasn't adjusted.