### PR TITLE
Fix NetworkPolicy templating, to allow metrics port scrapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix NetworkPolicy templating, to allow Pod ingress traffic (Prometheus scrape requests) on same port that the metrics/monitoring service advertises.
+
 ## [1.8.3] - 2020-07-31
 
 ### Fixed

--- a/helm/nginx-ingress-controller-app/templates/np.yaml
+++ b/helm/nginx-ingress-controller-app/templates/np.yaml
@@ -15,7 +15,7 @@ spec:
       protocol: TCP
     - port: 443
       protocol: TCP
-    - port: {{ .Values.controller.metricsPort }}
+    - port: {{ .Values.controller.metrics.port }}
       protocol: TCP
   egress:
   - {}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12642

This was broken with https://github.com/giantswarm/nginx-ingress-controller-app/pull/19