### PR TITLE
Configure helm hook weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+- Configure explicit helm hook wights to make validating webhook resource management reliable.
+
 ## [1.9.0] - 2020-08-13
 
 - Support Ingress resources validating webhook.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-- Configure explicit helm hook wights to make validating webhook resource management reliable.
+- Configure explicit helm hook weights to make validating webhook resource management reliable.
 
 ## [1.9.0] - 2020-08-13
 

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/clusterrole.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/clusterrole.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1"
   labels:
     {{- include "labels.common" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1"
   labels:
     {{- include "labels.common" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "0"
   labels:
     {{- include "labels.common" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "0"
   labels:
     {{- include "labels.common" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/np.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/np.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1"
   labels:
     {{- include "labels.common" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/psp.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/psp.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1"
   labels:
     {{- include "labels.common" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/role.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/role.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1"
   labels:
     {{- include "labels.common" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/rolebinding.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/rolebinding.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1"
   labels:
     {{- include "labels.common" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/serviceaccount.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/serviceaccount.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1"
   labels:
     {{- include "labels.common" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook

--- a/helm/nginx-ingress-controller-app/templates/test/test-runner.yaml
+++ b/helm/nginx-ingress-controller-app/templates/test/test-runner.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "resource.default.name" . }}-test
   annotations:
     "helm.sh/hook": test-success
+    "helm.sh/hook-weight": "0"
 spec:
   initContainers:
   # Bash automated testing system


### PR DESCRIPTION
NGINX validating webhook has two webhook patching jobs, admission webhook (secret) creation Job run at pre-install/pre-upgrade, and admission webhook patch Job run as post-install/pre-upgrade helm lifecycle phases via helm hook.

Installation was not reliable, sometimes it would fail. It was hard to debug. But today from a failure on a cluster using nginx 1.9.0 we've managed to learn more - secret creation Job was run there before RBAC resources got deployed, without them the Job Pod has no permission to manage Secret resources. I.e. source of unreliable webhook helm hook resource management was missing explicitly assigned weights and lack of guaranteed consistent ordering in Helm 2 when default weight (0) is assigned to all resources installed at helm lifecycle hook phases.

By https://helm.sh/docs/topics/charts_hooks/ it's good practice, even when ordering doesn't matter to assign explicitly hook weight of 0. In this case, ordering matters. Lower weight gets installed first.

This PR assigns weight of -1 to all the resources that have to be installed before Job resources, and Job resources get explicitly the default weight of 0, for better transparency.