### PR TITLE
pin kat version to git tag v0.5.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@0.13.0
+  architect: giantswarm/architect@0.15.0
 
 jobs:
   run-perf-tests:
@@ -19,7 +19,7 @@ jobs:
       - run: curl -Lo /tmp/helm.tar.gz https://get.helm.sh/helm-v2.16.5-linux-amd64.tar.gz
       - run: tar zxf /tmp/helm.tar.gz -C /tmp && mv /tmp/linux-amd64/helm /tmp/helm
       - run: /tmp/helm init -c
-      - run: curl -Lo /tmp/kind-app-testing.sh -q https://raw.githubusercontent.com/giantswarm/kube-app-testing/master/kube-app-testing.sh
+      - run: curl -Lo /tmp/kind-app-testing.sh -q https://raw.githubusercontent.com/giantswarm/kube-app-testing/v0.5.2/kube-app-testing.sh
       - run: chmod +x /tmp/kind-app-testing.sh
       - run: curl -Lo /tmp/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
       - run: chmod +x /tmp/kubectl


### PR DESCRIPTION
This PR pins the used `kube-app-testing.sh` script version to the current latest `v0.5.2`. This is done in preparation of upcoming changes in `kube-app-testing.sh`. (giantswarm/kube-app-testing#25)
