### PR TITLE
Extend ingress-controller config with unique key in values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add ability to extend `nginx-ingress-controller`with specific values from appcatalog. 
+
 ## [1.10.0] - 2020-10-07
 
 ### Changed

--- a/helm/nginx-ingress-controller-app/templates/configmap.yaml
+++ b/helm/nginx-ingress-controller-app/templates/configmap.yaml
@@ -7,3 +7,4 @@ metadata:
     {{- include "labels.common" . | nindent 4 }}
 data:
   {{- toYaml .Values.configmap | trim | nindent 2 }}
+  {{- toYaml .Values.ingressController.configmap | trim | nindent 2 }}

--- a/helm/nginx-ingress-controller-app/templates/configmap.yaml
+++ b/helm/nginx-ingress-controller-app/templates/configmap.yaml
@@ -7,4 +7,6 @@ metadata:
     {{- include "labels.common" . | nindent 4 }}
 data:
   {{- toYaml .Values.configmap | trim | nindent 2 }}
+  {{- if .Values.ingressController.controlPlane }}
   {{- toYaml .Values.ingressController.configmap | trim | nindent 2 }}
+  {{- end }}

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -344,13 +344,17 @@ initContainer:
 podSecurityPolicy:
   enabled: true
 
-# ingressController
+# ingressController.controlPlane
+# Defines if this app is installed into control-plane.
+#
+# ingressController.configmap
 # These values get applied directly to a configmap which configures the
 # nginx-ingress-controller
 # For all the nginx configmap config options see:
 # https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#configmaps
 # This is used  for control-plane specific configuration, which can be applied via control-plane catalog.
 ingressController:
+  controlPlane: false
   configmap: {}
 
 # test

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -344,6 +344,15 @@ initContainer:
 podSecurityPolicy:
   enabled: true
 
+# ingressController
+# These values get applied directly to a configmap which configures the
+# nginx-ingress-controller
+# For all the nginx configmap config options see:
+# https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#configmaps
+# This is used  for control-plane specific configuration, which can be applied via control-plane catalog.
+ingressController:
+  configmap: {}
+
 # test
 test:
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12893

We want to install this app into CP
But it requires a way to configure IC with values from catalog
Currently, we have `.Values.configmap`, but we can't put `configmap` option into control-plane catalog configuration. It is too generic.
That's why I'm adding this key
This doesn't look super nice, but we will get rid of it during migration to the new configuration management