### PR TITLE
allow control of antiaffinity scheduling via values.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Allow toggling of the `--update-status` flag. Disabling this feature stops NGINX IC from updating Ingress Loadbalancer status fields. ([#151](https://github.com/giantswarm/nginx-ingress-controller-app/pull/151))
 
+## Changed
+
+- Add ability to set podAntiAffinity scheduling method via the values file. ([#146](https://github.com/giantswarm/nginx-ingress-controller-app/pull/146))
+
 ## [1.11.0] - 2020-11-18
 
 ### Added

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
+          {{ .Values.controller.antiAffinityScheduling }}:
           - weight: 100
             podAffinityTerm:
               labelSelector:

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -55,6 +55,11 @@ controller:
   # Number of initial NGINX IC Deployment replicas.
   replicaCount: 1
 
+  # controller.antiAffinityScheduling
+  # Configures podAntiAffinity scheduling strategy.
+  # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  antiAffinityScheduling: preferredDuringSchedulingIgnoredDuringExecution
+
   # controller.maxUnavailable
   # Configures maximum number of unavailable replicas while doing a
   # rolling upgrade.


### PR DESCRIPTION
<!--
@app-squad-nginx will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- adds the ability to control anti-affinity scheduling rule via values.
