### PR TITLE
Bump container image version to 0.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Update image to `v0.43.0`. ([#165](https://github.com/giantswarm/nginx-ingress-controller-app/pull/165))
+
 ## [1.12.0] - 2020-12-09
 
 ### Added

--- a/helm/nginx-ingress-controller-app/Chart.yaml
+++ b/helm/nginx-ingress-controller-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v0.41.2
+appVersion: v0.43.0
 description: A Helm chart for the nginx ingress-controller
 home: https://github.com/giantswarm/nginx-ingress-controller-app
 icon: https://s.giantswarm.io/app-icons/1/png/nginx-ingress-controller-app-light.png

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -79,7 +79,7 @@ controller:
 
     # controller.image.tag
     # When updating tag make sure to also keep appVersion in Chart.yaml in sync
-    tag: v0.41.2
+    tag: v0.43.0
 
   # controller.containerPort
   containerPort:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/252

This PR bumps the used container image version to 0.43.0.