### PR TITLE
Annotate controller service for external-dns

### DIFF
--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -4,6 +4,9 @@ kind: Service
 metadata:
   annotations:
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.controller.service.subdomain }}.{{ .Values.baseDomain }}
+    {{- if .Values.controller.service.externalDNS.annotation }}
+    {{ .Values.controller.service.externalDNS.annotation }}
+    {{- end }}
   {{- if eq .Values.controller.service.type "LoadBalancer" }}
   {{- if eq .Values.provider "aws" }}
     {{- if not .Values.controller.service.public }}

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -307,6 +307,14 @@
                         "enabled": {
                             "type": "boolean"
                         },
+                        "externalDNS": {
+                            "type": "object",
+                            "properties": {
+                                "annotation": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "externalTrafficPolicy": {
                             "type": "string"
                         },

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -220,6 +220,13 @@ controller:
     # Do not overwrite this value.
     enabled: true
 
+    # controller.externalDNS
+    externalDNS:
+
+      # controller.externalDNS.annotation
+      # Assign an annotation to the controller's Service - this is used by external-dns to filter which resources it reconciles. Required for running multiple external-dns instances in a single cluster.
+      annotation: "giantswarm.io/external-dns: managed"
+
     # controller.service.externalTrafficPolicy
     # Configures kube-proxy, denotes if this Service desires to have external traffic routed to node-local or cluster-wide endpoints
     #   Local - kube-proxy only proxies requests to local endpoints (does not forward traffic to other nodes), source IP preserved


### PR DESCRIPTION
<!--
@app-squad-nginx will be automatically requested for review once
this PR has been submitted.
-->
This PR:

- adds an annotation to the controller service. This will be used by external-dns to limit the resources it reconciles.

See https://github.com/giantswarm/external-dns-app/pull/49
