### PR TITLE
Add configuration options to validating webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add configuration options for `failurePolicy` and `timeoutSeconds` of validating webhook configuration. ([#186](https://github.com/giantswarm/nginx-ingress-controller-app/pull/186))
+
 ## [1.15.0] - 2021-03-01
 
 ### Changed

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/validating-webhook.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/validating-webhook.yaml
@@ -20,7 +20,7 @@ webhooks:
     - UPDATE
     resources:
     - ingresses
-  failurePolicy: Fail
+  failurePolicy: {{ .Values.controller.admissionWebhooks.failurePolicy | default "Fail" }}
   sideEffects: None
   admissionReviewVersions:
     - v1beta1
@@ -30,4 +30,7 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       name: {{ include "resource.default.name" . }}-admission
       path: /networking/v1beta1/ingresses
+  {{- if .Values.controller.admissionWebhooks.timeoutSeconds }}
+  timeoutSeconds: {{ .Values.controller.admissionWebhooks.timeoutSeconds }}
+  {{- end }}
 {{- end }}

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -49,7 +49,12 @@
                             "type": "boolean"
                         },
                         "failurePolicy": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": ["Ignore", "Fail"]
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer",
+                            "minimum": 0
                         },
                         "patch": {
                             "type": "object",

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -296,6 +296,7 @@ controller:
   # rules from making their way into NGINX and potentially preventing the container from starting.
   admissionWebhooks:
     enabled: true
+    timeoutSeconds: 10
     failurePolicy: Fail
     port: 8443
 


### PR DESCRIPTION
Add configuration options for `failurePolicy` and `timeoutSeconds` of validating webhook configuration.