### PR TITLE
Upgrade 0.48.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@3.2.0
+  architect: giantswarm/architect@4.0.0
 
 workflows:
   version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Update controller container image to [`v0.48.1`](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v0.48.1). ([#211](https://github.com/giantswarm/nginx-ingress-controller-app/pull/211)). This release contains several performance improvements related to the admission webhook.
-- Breaking: Define `--disable-svc-external-name` flag by default to disable forwarding to [ExternalName Services](https://kubernetes.io/docs/concepts/services-networking/service/#externalname). If you require this feature, you can enable forwarding again setting this flag through user values `controller.disableExternalNameForwarding: false`. ([#211](https://github.com/giantswarm/nginx-ingress-controller-app/pull/211))
+- Breaking: Define `--disable-svc-external-name` flag by default to disable forwarding traffic to [ExternalName Services](https://kubernetes.io/docs/concepts/services-networking/service/#externalname). If you require this feature, you can enable forwarding again through setting `controller.disableExternalNameForwarding: false` in user values. ([#211](https://github.com/giantswarm/nginx-ingress-controller-app/pull/211))
 
 ## [1.17.0] - 2021-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Update controller container image to [`v0.48.1`](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v0.48.1). ([#211](https://github.com/giantswarm/nginx-ingress-controller-app/pull/211)). This release contains several performance improvements related to the admission webhook.
+- Breaking: Specify `--disable-svc-external-name` flag by default to disable forwarding to [ExternalName Services](https://kubernetes.io/docs/concepts/services-networking/service/#externalname). If you require this feature, you can disable setting this flag through user values by setting `controller.disableExternalNameForwarding` to `true`. ([#211](https://github.com/giantswarm/nginx-ingress-controller-app/pull/211))
+
 ## [1.17.0] - 2021-06-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Update controller container image to [`v0.48.1`](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v0.48.1). ([#211](https://github.com/giantswarm/nginx-ingress-controller-app/pull/211)). This release contains several performance improvements related to the admission webhook.
-- Breaking: Specify `--disable-svc-external-name` flag by default to disable forwarding to [ExternalName Services](https://kubernetes.io/docs/concepts/services-networking/service/#externalname). If you require this feature, you can disable setting this flag through user values by setting `controller.disableExternalNameForwarding` to `true`. ([#211](https://github.com/giantswarm/nginx-ingress-controller-app/pull/211))
+- Breaking: Define `--disable-svc-external-name` flag by default to disable forwarding to [ExternalName Services](https://kubernetes.io/docs/concepts/services-networking/service/#externalname). If you require this feature, you can enable forwarding again setting this flag through user values `controller.disableExternalNameForwarding: false`. ([#211](https://github.com/giantswarm/nginx-ingress-controller-app/pull/211))
 
 ## [1.17.0] - 2021-06-16
 

--- a/helm/nginx-ingress-controller-app/Chart.yaml
+++ b/helm/nginx-ingress-controller-app/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: v0.47.0
+appVersion: v0.48.1
 description: A Helm chart for the nginx ingress-controller
 home: https://github.com/giantswarm/nginx-ingress-controller-app
 icon: https://s.giantswarm.io/app-icons/1/png/nginx-ingress-controller-app-light.png
 kubeVersion: ">=1.16.0-0"
 name: nginx-ingress-controller-app
-version: 1.17.0
+version: 2.0.0

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -104,6 +104,9 @@ spec:
         - --validating-webhook-key=/usr/local/certificates/key
         {{- end }}
         - --update-status={{ .Values.controller.updateIngressStatus }}
+        {{- if .Values.controller.disableExternalNameForwarding }}
+        - --disable-svc-external-name
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: true
           capabilities:

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -79,7 +79,7 @@ controller:
 
     # controller.image.tag
     # When updating tag make sure to also keep appVersion in Chart.yaml in sync
-    tag: v0.47.0
+    tag: v0.48.1
 
   # controller.containerPort
   containerPort:

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -360,6 +360,11 @@ controller:
     # (.spec.template.metadata.annotations).
     pod: []
 
+  # controller.disableExternalNameForwarding
+  # Enable or disable forwarding to ExternalName Services through
+  # --disable-svc-external-name flag
+  disableExternalNameForwarding: true
+
 # image
 image:
   registry: quay.io


### PR DESCRIPTION
This PR upgrades the controller image to 0.48.1

From this point on, the flag `--disable-svc-external-name` flag is  set by default to disable forwarding to [ExternalName Services](https://kubernetes.io/docs/concepts/services-networking/service/#externalname). If you require this feature, you can disable setting this flag through user values by setting `controller.disableExternalNameForwarding` to `true`.