### PR TITLE
Upgrade to nginx-ingress-controller v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking change** Update controller container image to [`v1.0.0`](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#100). From this version on, only clusters with kubernetes >= 1.19 are supported. ([#218](https://github.com/giantswarm/nginx-ingress-controller-app/pull/218)).
+
 ## [2.1.0] - 2021-08-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- **Breaking change** Update controller container image to [`v1.0.0`](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#100). From this version on, only clusters with kubernetes >= 1.19 are supported. ([#218](https://github.com/giantswarm/nginx-ingress-controller-app/pull/218)).
+- **Breaking change** Update controller container image to [`v1.0.0`](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#100). From this version on, only clusters with kubernetes >= 1.19 are supported. Please make sure to read the [upgrading notes](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/README.md#upgrading-notes). ([#218](https://github.com/giantswarm/nginx-ingress-controller-app/pull/218)).
 
 ## [2.1.0] - 2021-08-26
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Version [2.2.0](./CHANGELOG.md#TODO) of the nginx Ingress Controller app contain
 
 Additionally, you'll have to make sure your Ingress resources are using the `spec.IngressClassName` (or the deprecated `kubernetes.io/ingress.class` annotation) matching the name of your IngressClass (default `nginx`).
 
+In case it is not possible to update all Ingress resources to specify the `spec.IngressClassName`, you can specify `controller.watchIngressWithoutClass` to `true` in your [user configuration](#configuration-options). Please make sure there is no other Ingress Controller deployed to your cluster.
+
 You can find more information in the upstream [migration to networking.k8s.io/v1 FAQ](https://github.com/kubernetes/ingress-nginx/blob/main/docs/index.md#faq---migration-to-apiversion-networkingk8siov1).
 
 ## Installing

--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ updates to the Ingress resource.
 
 ## Upgrading notes
 
-Version [2.2.0](./CHANGELOG.md#TODO) of the nginx Ingress Controller app contains version [1.0.0](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.0.0)
+Version [2.2.0](./CHANGELOG.md#220---2021-09-09) of the nginx Ingress Controller app contains version [1.0.0](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.0.0)
 
 ### Prerequisites
 - kubernetes version >= 1.19
 - requires `networking.k8s.io/v1` (`extensions/v1beta1` or `networking.k8s.io/v1beta1` are no longer supported)
-- An IngressClass (One will be created when installing app version [2.2.0](TODO))
+- An IngressClass (One will be created when installing app version [2.2.0](./CHANGELOG.md#220---2021-09-09))
 
 Additionally, you'll have to make sure your Ingress resources are using the `spec.IngressClassName` (or the deprecated `kubernetes.io/ingress.class` annotation) matching the name of your IngressClass (default `nginx`).
 

--- a/README.md
+++ b/README.md
@@ -39,12 +39,15 @@ updates to the Ingress resource.
 
 ## Upgrading notes
 
-Version [2.2.0](./CHANGELOG.md#TODO) of the nginx Ingress Controller app contains upstream version [1.0.0] which won't work, if
+Version [2.2.0](./CHANGELOG.md#TODO) of the nginx Ingress Controller app contains version [1.0.0](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.0.0) of the nginx-ingress controller which won't work, if
 
 - the kubernetes version of your cluster is below 1.19
 - you're using Ingress resources with api version `extensions/v1beta1` or `networking.k8s.io/v1beta1`
-- you don't have a default IngressClass. (This will be created when installing app version [2.2.0])
+- you don't have an IngressClass. (This will be created when installing app version [2.2.0](TODO))
 
+Additionally, you'll have to make sure your Ingress resources are using the `spec.IngressClassName` (or the deprecated `kubernetes.io/ingress.class` annotation) matching the name of your IngressClass (default `nginx`).
+
+You can find more information in the upstream [migration to networking.k8s.io/v1 FAQ](https://github.com/kubernetes/ingress-nginx/blob/main/docs/index.md#faq---migration-to-apiversion-networkingk8siov1).
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,16 @@ updates to the Ingress resource.
 - [What is this repo?](#what-is-this-repo)
 
 
-# Installing
+## Upgrading notes
+
+Version [2.2.0](./CHANGELOG.md#TODO) of the nginx Ingress Controller app contains upstream version [1.0.0] which won't work, if
+
+- the kubernetes version of your cluster is below 1.19
+- you're using Ingress resources with api version `extensions/v1beta1` or `networking.k8s.io/v1beta1`
+- you don't have a default IngressClass. (This will be created when installing app version [2.2.0])
+
+
+## Installing
 
 There are 3 ways to install this app onto a workload cluster.
 
@@ -45,7 +54,7 @@ There are 3 ways to install this app onto a workload cluster.
 2. [Using our API](https://docs.giantswarm.io/api/#operation/createClusterAppV5)
 3. Directly creating the [App custom resource](https://docs.giantswarm.io/ui-api/management-api/crd/apps.application.giantswarm.io/) on the management cluster.
 
-## Sample values files for the web interface and API
+### Sample values files for the web interface and API
 
 This is an example of the values file you could upload using our web interface.
 
@@ -69,7 +78,7 @@ structure but formatted as JSON:
 }
 ```
 
-## Sample App CR and ConfigMap for the management cluster
+### Sample App CR and ConfigMap for the management cluster
 
 If you have access to the Kubernetes API on the management cluster, you could create
 the App CR and ConfigMap directly.
@@ -83,7 +92,6 @@ apiVersion: application.giantswarm.io/v1alpha1
 kind: App
 metadata:
   labels:
-    app-operator.giantswarm.io/version: 1.0.0
   name: nginx-ingress-controller-app
 
   # workload cluster resources live in a namespace with the same ID as the
@@ -94,30 +102,11 @@ spec:
   name: nginx-ingress-controller-app
   namespace: kube-system
   catalog: giantswarm
-  version: 1.6.8
+  version: 2.2.0
 
   userConfig:
     configMap:
       name: nginx-ingress-controller-app-user-values
-      namespace: abc12
-    secret:
-      name: ""
-      namespace: ""
-
-  config:
-    configMap:
-      name: ingress-controller-values
-      namespace: abc12
-    secret:
-      name: ""
-      namespace: ""
-
-  kubeConfig:
-    context:
-      name: abc12-kubeconfig
-    inCluster: false
-    secret:
-      name: abc12-kubeconfig
       namespace: abc12
 ```
 
@@ -150,7 +139,7 @@ with id `abc12`.
 
 See our [full reference page on how to configure applications](https://docs.giantswarm.io/app-platform/app-configuration/) for more details.
 
-## Important note about required cluster level config
+### Important note about required cluster level config
 
 The `ingress-controller-values` ConfigMap referenced in the `spec.config` field of the App CR
 is required for the ingress controller to work properly.
@@ -161,20 +150,20 @@ our API, `spec.config` will be set automatically, but if you are creating the Ap
 yourself you must remember to do this. We are working on a kubectl plugin to
 facilitate this process.
 
-# Configuration Options
+## Configuration Options
 
 All configuration options are documented in the [values.yaml](/helm/nginx-ingress-controller-app/values.yaml) file.
 
-# Limitations
+## Limitations
 
 Some of our apps have certain restrictions on how they can be deployed.
 Not following these limitations will most likely result in a broken deployment.
 
 - This app _must_ reference the `ingress-controller-values` ConfigMap in its `spec.config` field.
 
-# For developers
+## For developers
 
-## Installing the Chart locally
+### Installing the Chart locally
 
 To install the chart locally:
 
@@ -190,12 +179,11 @@ Provide a custom `values.yaml`:
 $ helm install nginx-ingress-controller-app -f values.yaml
 ```
 
-## Release Process
+### Release Process
 
 * Ensure CHANGELOG.md is up to date.
-* Create a new GitHub release with the version e.g. `v0.1.0` and link the
-changelog entry.
-* This will push a new git tag and trigger a new tarball to be pushed to the
+* Create a new branch with name `master#release#vX.X.X`. Automation will create a release PR.
+* Merging the release PR will push a new git tag and trigger a new tarball to be pushed to the
 [giantswarm-catalog] and [default-catalog].
 * Test and verify the ingress controller release across supported environments in a new or existing WIP platform release.
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ updates to the Ingress resource.
 
 ## Upgrading notes
 
-Version [2.2.0](./CHANGELOG.md#TODO) of the nginx Ingress Controller app contains version [1.0.0](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.0.0) of the nginx-ingress controller which won't work, if
+Version [2.2.0](./CHANGELOG.md#TODO) of the nginx Ingress Controller app contains version [1.0.0](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.0.0)
 
-- the kubernetes version of your cluster is below 1.19
-- you're using Ingress resources with api version `extensions/v1beta1` or `networking.k8s.io/v1beta1`
-- you don't have an IngressClass. (This will be created when installing app version [2.2.0](TODO))
+### Prerequisites
+- kubernetes version >= 1.19
+- requires `networking.k8s.io/v1` (`extensions/v1beta1` or `networking.k8s.io/v1beta1` are no longer supported)
+- An IngressClass (One will be created when installing app version [2.2.0](TODO))
 
 Additionally, you'll have to make sure your Ingress resources are using the `spec.IngressClassName` (or the deprecated `kubernetes.io/ingress.class` annotation) matching the name of your IngressClass (default `nginx`).
 

--- a/helm/nginx-ingress-controller-app/Chart.yaml
+++ b/helm/nginx-ingress-controller-app/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: v0.49.0
+appVersion: v1.0.0
 description: A Helm chart for the nginx ingress-controller
 home: https://github.com/giantswarm/nginx-ingress-controller-app
 icon: https://s.giantswarm.io/app-icons/1/png/nginx-ingress-controller-app-light.png
-kubeVersion: ">=1.16.0-0"
+kubeVersion: ">=1.19.0-0"
 name: nginx-ingress-controller-app
-version: 2.0.0
+version: 2.2.0

--- a/helm/nginx-ingress-controller-app/templates/_helpers.tpl
+++ b/helm/nginx-ingress-controller-app/templates/_helpers.tpl
@@ -51,3 +51,13 @@ Election ID.
 {{- define "controller.leader.election.id" -}}
 {{ include "resource.default.name" . }}-leader
 {{- end -}}
+
+{{/*
+IngressClass parameters.
+*/}}
+{{- define "ingressClass.parameters" -}}
+  {{- if .Values.controller.ingressClassResource.parameters -}}
+          parameters:
+{{ toYaml .Values.controller.ingressClassResource.parameters | indent 4}}
+  {{ end }}
+{{- end -}}

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/validating-webhook.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/validating-webhook.yaml
@@ -14,7 +14,7 @@ webhooks:
   - apiGroups:
     - networking.k8s.io
     apiVersions:
-    - v1beta1
+    - v1
     operations:
     - CREATE
     - UPDATE
@@ -23,13 +23,12 @@ webhooks:
   failurePolicy: {{ .Values.controller.admissionWebhooks.failurePolicy | default "Fail" }}
   sideEffects: None
   admissionReviewVersions:
-    - v1beta1
     - v1
   clientConfig:
     service:
       namespace: {{ .Release.Namespace }}
       name: {{ include "resource.default.name" . }}-admission
-      path: /networking/v1beta1/ingresses
+      path: /networking/v1/ingresses
   {{- if .Values.controller.admissionWebhooks.timeoutSeconds }}
   timeoutSeconds: {{ .Values.controller.admissionWebhooks.timeoutSeconds }}
   {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -93,7 +93,7 @@ spec:
         {{- end}}
         - --enable-ssl-chain-completion=false
         {{- if .Values.controller.ingressClass }}
-        - --ingress-class={{ .Values.controller.ingressClass }}
+        - --controller-class={{ .Values.controller.ingressClass }}
         {{- end}}
         {{- if .Values.controller.service.enabled }}
         - --publish-service={{ .Release.Namespace }}/{{ include "resource.default.name" . }}
@@ -106,6 +106,9 @@ spec:
         - --update-status={{ .Values.controller.updateIngressStatus }}
         {{- if .Values.controller.disableExternalNameForwarding }}
         - --disable-svc-external-name
+        {{- end }}
+        {{- if .Values.controller.watchIngressWithoutClass }}
+        - --watch-ingress-without-class=true
         {{- end }}
         securityContext:
           allowPrivilegeEscalation: true

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -92,9 +92,7 @@ spec:
         - --default-ssl-certificate={{ .Values.controller.defaultSSLCertificate }}
         {{- end}}
         - --enable-ssl-chain-completion=false
-        {{- if .Values.controller.ingressClass }}
-        - --controller-class={{ .Values.controller.ingressClass }}
-        {{- end}}
+        - --controller-class={{ .Values.controller.ingressClassResource.controllerValue }}
         {{- if .Values.controller.service.enabled }}
         - --publish-service={{ .Release.Namespace }}/{{ include "resource.default.name" . }}
         {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/controller-ingressclass.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-ingressclass.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.controller.ingressClassResource.enabled -}}
+# We don't support namespaced ingressClass yet
+# So a ClusterRole and a ClusterRoleBinding is required
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: {{ .Values.controller.ingressClassResource.name }}
+{{- if .Values.controller.ingressClassResource.default }}
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
+{{- end }}
+spec:
+  controller: {{ .Values.controller.ingressClassResource.controllerValue }}
+  {{ template "ingressClass.parameters" . }}
+{{- end }}

--- a/helm/nginx-ingress-controller-app/templates/rbac.yaml
+++ b/helm/nginx-ingress-controller-app/templates/rbac.yaml
@@ -63,7 +63,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - extensions
   - networking.k8s.io
   resources:
   - ingresses
@@ -79,7 +78,6 @@ rules:
   - create
   - patch
 - apiGroups:
-  - extensions
   - networking.k8s.io
   resources:
   - ingresses/status
@@ -111,7 +109,7 @@ rules:
     # "<election-id>-<ingress-class>" ConfigMap is used for leader election.
     # Leader is nginx controller replica that manages to update the lock on it.
   {{- if .Values.controller.ingressClass }}
-  - "{{ include "controller.leader.election.id" . }}-{{ .Values.controller.ingressClass }}"
+  - "{{ include "controller.leader.election.id" . }}"
   {{- end }}
   verbs:
   - get

--- a/helm/nginx-ingress-controller-app/templates/rbac.yaml
+++ b/helm/nginx-ingress-controller-app/templates/rbac.yaml
@@ -83,6 +83,14 @@ rules:
   - ingresses/status
   verbs:
   - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -95,9 +103,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  - pods
-  - secrets
   - namespaces
   verbs:
   - get
@@ -105,12 +110,49 @@ rules:
   - ""
   resources:
   - configmaps
+  - pods
+  - secrets
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
   resourceNames:
-    # "<election-id>-<ingress-class>" ConfigMap is used for leader election.
-    # Leader is nginx controller replica that manages to update the lock on it.
-  {{- if .Values.controller.ingressClass }}
   - "{{ include "controller.leader.election.id" . }}"
-  {{- end }}
   verbs:
   - get
   - update
@@ -123,11 +165,10 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - endpoints
+  - events
   verbs:
-  - get
   - create
-  - update
+  - patch
 {{- if .Values.podSecurityPolicy.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/nginx-ingress-controller-app/tests/abs/Pipfile
+++ b/helm/nginx-ingress-controller-app/tests/abs/Pipfile
@@ -3,14 +3,10 @@ name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 
-[dev-packages]
-pre-commit = "*"
-
 [packages]
-pytest-helm-charts = ">=0.3.1"
+pytest-helm-charts = ">=0.5.2"
 pytest = ">=6.1.2"
 pykube-ng = ">=20.10.0"
-pyyaml = "*"
 pytest-rerunfailures = "*"
 requests = "*"
 

--- a/helm/nginx-ingress-controller-app/tests/abs/Pipfile.lock
+++ b/helm/nginx-ingress-controller-app/tests/abs/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "71885f1df74778edcd6cba18f05e6535cfc6abe445996acf22e5c5270409a518"
+            "sha256": "a44d2ad283435eb4ef551a85301a2610f1400e57c767822f7239f1c9190fdd85"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -21,6 +21,7 @@
                 "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
                 "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==21.2.0"
         },
         "certifi": {
@@ -30,19 +31,21 @@
             ],
             "version": "==2021.5.30"
         },
-        "chardet": {
+        "charset-normalizer": {
             "hashes": [
-                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
-                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
+                "sha256:0c8911edd15d19223366a194a513099a302055a962bca2cec0f54b8b63175d8b",
+                "sha256:f23667ebe1084be45f6ae0538e4a5a865206544097e4e8bbcacf42cd02a348f3"
             ],
-            "version": "==4.0.0"
+            "markers": "python_version >= '3'",
+            "version": "==2.0.4"
         },
         "idna": {
             "hashes": [
-                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
-                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
+                "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a",
+                "sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3"
             ],
-            "version": "==2.10"
+            "markers": "python_version >= '3'",
+            "version": "==3.2"
         },
         "iniconfig": {
             "hashes": [
@@ -53,16 +56,18 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
-                "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"
+                "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7",
+                "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"
             ],
-            "version": "==20.9"
+            "markers": "python_version >= '3.6'",
+            "version": "==21.0"
         },
         "pluggy": {
             "hashes": [
                 "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
                 "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.13.1"
         },
         "py": {
@@ -70,196 +75,108 @@
                 "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
                 "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.10.0"
         },
         "pykube-ng": {
             "hashes": [
-                "sha256:72c5fbff0da32ec1682927167742f4ebf7b33a1ad01035511d5fec2de208220f",
-                "sha256:d6a5f9101719d461db1f7e11cfdde4c1f8bae5c6a89f4c08e5008aae9327b338"
+                "sha256:06d73e639d4c63979798042247330e6b9e7072e4a2be84a0ea4793e633787970",
+                "sha256:d0824fab6b5c1f25ca5d4b348a9556545603d1ff9251e126fd4008a34e142dc3"
             ],
             "index": "pypi",
-            "version": "==20.10.0"
+            "version": "==21.3.0"
         },
         "pyparsing": {
             "hashes": [
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "pytest": {
             "hashes": [
-                "sha256:1969f797a1a0dbd8ccf0fecc80262312729afea9c17f1d70ebf85c5e76c6f7c8",
-                "sha256:66e419b1899bc27346cb2c993e12c5e5e8daba9073c1fbce33b9807abc95c306"
+                "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b",
+                "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"
             ],
             "index": "pypi",
-            "version": "==6.2.1"
+            "version": "==6.2.4"
         },
         "pytest-helm-charts": {
             "hashes": [
-                "sha256:39f96bd36b42c6575fee2e0522ea7d6d8ed97e6f621cede1b7a4e80616b130f1",
-                "sha256:e9cedf5e1027931e38c65b285d34650b0347a9ff1c3e72e0452e34578f08be3b"
+                "sha256:867de2892516c90e387fd26df589d6b961e8130e6a4b6a86e6ff99082ae91202",
+                "sha256:ed441a4401a45f7ee968640f5f5598a6f79a57f781204dfb2383b01af8540cec"
             ],
             "index": "pypi",
-            "version": "==0.3.1"
+            "version": "==0.5.2"
         },
         "pytest-rerunfailures": {
             "hashes": [
-                "sha256:1cb11a17fc121b3918414eb5eaf314ee325f2e693ac7cb3f6abf7560790827f2",
-                "sha256:2eb7d0ad651761fbe80e064b0fd415cf6730cdbc53c16a145fd84b66143e609f"
+                "sha256:53db94acf7499c75c5257c79d8a1dc22c3db4bc8d32ec3a713ea91eda3f98359",
+                "sha256:7617c06de13ee6dd2df9add7e275bfb2bcebbaaf3e450f5937cd0200df824273"
             ],
             "index": "pypi",
-            "version": "==9.1.1"
+            "version": "==10.1"
         },
         "pyyaml": {
             "hashes": [
-                "sha256:02c78d77281d8f8d07a255e57abdbf43b02257f59f50cc6b636937d68efa5dd0",
-                "sha256:0dc9f2eb2e3c97640928dec63fd8dc1dd91e6b6ed236bd5ac00332b99b5c2ff9",
-                "sha256:124fd7c7bc1e95b1eafc60825f2daf67c73ce7b33f1194731240d24b0d1bf628",
-                "sha256:26fcb33776857f4072601502d93e1a619f166c9c00befb52826e7b774efaa9db",
-                "sha256:31ba07c54ef4a897758563e3a0fcc60077698df10180abe4b8165d9895c00ebf",
-                "sha256:3c49e39ac034fd64fd576d63bb4db53cda89b362768a67f07749d55f128ac18a",
-                "sha256:52bf0930903818e600ae6c2901f748bc4869c0c406056f679ab9614e5d21a166",
-                "sha256:5a3f345acff76cad4aa9cb171ee76c590f37394186325d53d1aa25318b0d4a09",
-                "sha256:5e7ac4e0e79a53451dc2814f6876c2fa6f71452de1498bbe29c0b54b69a986f4",
-                "sha256:7242790ab6c20316b8e7bb545be48d7ed36e26bbe279fd56f2c4a12510e60b4b",
-                "sha256:737bd70e454a284d456aa1fa71a0b429dd527bcbf52c5c33f7c8eee81ac16b89",
-                "sha256:8635d53223b1f561b081ff4adecb828fd484b8efffe542edcfdff471997f7c39",
-                "sha256:8b818b6c5a920cbe4203b5a6b14256f0e5244338244560da89b7b0f1313ea4b6",
-                "sha256:8bf38641b4713d77da19e91f8b5296b832e4db87338d6aeffe422d42f1ca896d",
-                "sha256:a36a48a51e5471513a5aea920cdad84cbd56d70a5057cca3499a637496ea379c",
-                "sha256:b2243dd033fd02c01212ad5c601dafb44fbb293065f430b0d3dbf03f3254d615",
-                "sha256:cc547d3ead3754712223abb7b403f0a184e4c3eae18c9bb7fd15adef1597cc4b",
-                "sha256:cc552b6434b90d9dbed6a4f13339625dc466fd82597119897e9489c953acbc22",
-                "sha256:f3790156c606299ff499ec44db422f66f05a7363b39eb9d5b064f17bd7d7c47b",
-                "sha256:f7a21e3d99aa3095ef0553e7ceba36fb693998fbb1226f1392ce33681047465f",
-                "sha256:fdc6b2cb4b19e431994f25a9160695cc59a4e861710cc6fc97161c5e845fc579"
+                "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
+                "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696",
+                "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393",
+                "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77",
+                "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922",
+                "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5",
+                "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8",
+                "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10",
+                "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc",
+                "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018",
+                "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
+                "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253",
+                "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347",
+                "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183",
+                "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541",
+                "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb",
+                "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185",
+                "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc",
+                "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db",
+                "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa",
+                "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46",
+                "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122",
+                "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b",
+                "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63",
+                "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
+                "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc",
+                "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247",
+                "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6",
+                "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"
             ],
-            "index": "pypi",
-            "version": "==5.4"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==5.4.1"
         },
         "requests": {
             "hashes": [
-                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
-                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
+                "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
+                "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
             ],
             "index": "pypi",
-            "version": "==2.25.1"
+            "version": "==2.26.0"
         },
         "toml": {
             "hashes": [
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
         },
         "urllib3": {
             "hashes": [
-                "sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c",
-                "sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
+                "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
+                "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
             ],
-            "index": "pypi",
-            "version": "==1.26.5"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
+            "version": "==1.26.6"
         }
     },
-    "develop": {
-        "appdirs": {
-            "hashes": [
-                "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41",
-                "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"
-            ],
-            "version": "==1.4.4"
-        },
-        "cfgv": {
-            "hashes": [
-                "sha256:9e600479b3b99e8af981ecdfc80a0296104ee610cab48a5ae4ffd0b668650eb1",
-                "sha256:b449c9c6118fe8cca7fa5e00b9ec60ba08145d281d52164230a69211c5d597a1"
-            ],
-            "version": "==3.3.0"
-        },
-        "distlib": {
-            "hashes": [
-                "sha256:106fef6dc37dd8c0e2c0a60d3fca3e77460a48907f335fa28420463a6f799736",
-                "sha256:23e223426b28491b1ced97dc3bbe183027419dfc7982b4fa2f05d5f3ff10711c"
-            ],
-            "version": "==0.3.2"
-        },
-        "filelock": {
-            "hashes": [
-                "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59",
-                "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"
-            ],
-            "version": "==3.0.12"
-        },
-        "identify": {
-            "hashes": [
-                "sha256:92d6ad08eca19ceb17576733759944b94c0761277ddc3acf65e75e57ef190e32",
-                "sha256:c29e74c3671fe9537715cb695148231d777170ca1498e1c30c675d4ea782afe9"
-            ],
-            "version": "==2.2.7"
-        },
-        "nodeenv": {
-            "hashes": [
-                "sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b",
-                "sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7"
-            ],
-            "version": "==1.6.0"
-        },
-        "pre-commit": {
-            "hashes": [
-                "sha256:6c86d977d00ddc8a60d68eec19f51ef212d9462937acf3ea37c7adec32284ac0",
-                "sha256:ee784c11953e6d8badb97d19bc46b997a3a9eded849881ec587accd8608d74a4"
-            ],
-            "index": "pypi",
-            "version": "==2.9.3"
-        },
-        "pyyaml": {
-            "hashes": [
-                "sha256:02c78d77281d8f8d07a255e57abdbf43b02257f59f50cc6b636937d68efa5dd0",
-                "sha256:0dc9f2eb2e3c97640928dec63fd8dc1dd91e6b6ed236bd5ac00332b99b5c2ff9",
-                "sha256:124fd7c7bc1e95b1eafc60825f2daf67c73ce7b33f1194731240d24b0d1bf628",
-                "sha256:26fcb33776857f4072601502d93e1a619f166c9c00befb52826e7b774efaa9db",
-                "sha256:31ba07c54ef4a897758563e3a0fcc60077698df10180abe4b8165d9895c00ebf",
-                "sha256:3c49e39ac034fd64fd576d63bb4db53cda89b362768a67f07749d55f128ac18a",
-                "sha256:52bf0930903818e600ae6c2901f748bc4869c0c406056f679ab9614e5d21a166",
-                "sha256:5a3f345acff76cad4aa9cb171ee76c590f37394186325d53d1aa25318b0d4a09",
-                "sha256:5e7ac4e0e79a53451dc2814f6876c2fa6f71452de1498bbe29c0b54b69a986f4",
-                "sha256:7242790ab6c20316b8e7bb545be48d7ed36e26bbe279fd56f2c4a12510e60b4b",
-                "sha256:737bd70e454a284d456aa1fa71a0b429dd527bcbf52c5c33f7c8eee81ac16b89",
-                "sha256:8635d53223b1f561b081ff4adecb828fd484b8efffe542edcfdff471997f7c39",
-                "sha256:8b818b6c5a920cbe4203b5a6b14256f0e5244338244560da89b7b0f1313ea4b6",
-                "sha256:8bf38641b4713d77da19e91f8b5296b832e4db87338d6aeffe422d42f1ca896d",
-                "sha256:a36a48a51e5471513a5aea920cdad84cbd56d70a5057cca3499a637496ea379c",
-                "sha256:b2243dd033fd02c01212ad5c601dafb44fbb293065f430b0d3dbf03f3254d615",
-                "sha256:cc547d3ead3754712223abb7b403f0a184e4c3eae18c9bb7fd15adef1597cc4b",
-                "sha256:cc552b6434b90d9dbed6a4f13339625dc466fd82597119897e9489c953acbc22",
-                "sha256:f3790156c606299ff499ec44db422f66f05a7363b39eb9d5b064f17bd7d7c47b",
-                "sha256:f7a21e3d99aa3095ef0553e7ceba36fb693998fbb1226f1392ce33681047465f",
-                "sha256:fdc6b2cb4b19e431994f25a9160695cc59a4e861710cc6fc97161c5e845fc579"
-            ],
-            "index": "pypi",
-            "version": "==5.4"
-        },
-        "six": {
-            "hashes": [
-                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
-                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
-            ],
-            "version": "==1.16.0"
-        },
-        "toml": {
-            "hashes": [
-                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
-                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
-            ],
-            "version": "==0.10.2"
-        },
-        "virtualenv": {
-            "hashes": [
-                "sha256:14fdf849f80dbb29a4eb6caa9875d476ee2a5cf76a5f5415fa2f1606010ab467",
-                "sha256:2b0126166ea7c9c3661f5b8e06773d28f83322de7a3ff7d06f0aed18c9de6a76"
-            ],
-            "version": "==20.4.7"
-        }
-    }
+    "develop": {}
 }

--- a/helm/nginx-ingress-controller-app/tests/abs/multi-controller-manifests.yaml
+++ b/helm/nginx-ingress-controller-app/tests/abs/multi-controller-manifests.yaml
@@ -1,0 +1,150 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: second-ingress-controller
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: helloworld-2
+---
+apiVersion: v1
+data:
+  values: |
+    configmap:
+      worker-processes: "2"
+    controller:
+      ingressClassResource:
+        name: second-ingress
+        controllerValue: "k8s.io/ingress-nginx2"
+      autoscaling:
+        enabled: false
+      service:
+        type: NodePort
+        nodePorts:
+          http: 30012
+          https: 30013
+    cluster:
+      profile: 1
+kind: ConfigMap
+metadata:
+  name: second-ingress-controller-cm
+  namespace: second-ingress-controller
+---
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  labels:
+    app-operator.giantswarm.io/version: 0.0.0
+  name: second-ingress-controller
+  namespace: second-ingress-controller
+spec:
+  catalog: chartmuseum
+  config:
+    configMap:
+      name: second-ingress-controller-cm
+      namespace: second-ingress-controller
+  kubeConfig:
+    inCluster: true
+  name: nginx-ingress-controller-app
+  namespace: second-ingress-controller
+  version: 0.1.0-overwrittenbypatch
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: helloworld-2
+  name: helloworld-2
+  namespace: helloworld-2
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: helloworld-2
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: helloworld-2
+    spec:
+      containers:
+      - image: quay.io/giantswarm/helloworld:latest
+        imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: helloworld-2
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext:
+        runAsUser: 1000
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: helloworld-2
+  name: helloworld-2
+  namespace: helloworld-2
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: helloworld-2
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app: helloworld-2
+  name: helloworld-2
+  namespace: helloworld-2
+spec:
+  ingressClassName: second-ingress
+  rules:
+  - host: helloworld-2
+    http:
+      paths:
+      - backend:
+          service:
+            name: helloworld-2
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix

--- a/helm/nginx-ingress-controller-app/tests/abs/test-ingress.yaml
+++ b/helm/nginx-ingress-controller-app/tests/abs/test-ingress.yaml
@@ -1,0 +1,102 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: helloworld
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: helloworld
+  name: helloworld
+  namespace: helloworld
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: helloworld
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: helloworld
+    spec:
+      containers:
+      - image: quay.io/giantswarm/helloworld:latest
+        imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: helloworld
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext:
+        runAsUser: 1000
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: helloworld
+  name: helloworld
+  namespace: helloworld
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: helloworld
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app: helloworld
+  name: helloworld
+  namespace: helloworld
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: helloworld
+    http:
+      paths:
+      - backend:
+          service:
+            name: helloworld
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -186,8 +186,36 @@
                         }
                     }
                 },
-                "ingressClass": {
-                    "type": "string"
+                "ingressClassResource": {
+                    "type": "object",
+                    "properties": {
+                        "controllerValue": {
+                            "type": "string"
+                        },
+                        "default": {
+                            "type": "boolean"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "apiGroup": {
+                                    "type": "string"
+                                },
+                                "kind": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
                 },
                 "lifecycle": {
                     "type": "object",

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -52,10 +52,6 @@
                             "type": "string",
                             "enum": ["Ignore", "Fail"]
                         },
-                        "timeoutSeconds": {
-                            "type": "integer",
-                            "minimum": 0
-                        },
                         "patch": {
                             "type": "object",
                             "properties": {
@@ -109,6 +105,10 @@
                                     "type": "string"
                                 }
                             }
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer",
+                            "minimum": 0
                         }
                     }
                 },
@@ -151,6 +151,9 @@
                 },
                 "defaultSSLCertificate": {
                     "type": "string"
+                },
+                "disableExternalNameForwarding": {
+                    "type": "boolean"
                 },
                 "enableMimalloc": {
                     "type": "boolean"
@@ -323,14 +326,11 @@
                 "service": {
                     "type": "object",
                     "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
                         "annotations": {
                             "type": "object"
                         },
-                        "labels": {
-                            "type": "object"
+                        "enabled": {
+                            "type": "boolean"
                         },
                         "externalDNS": {
                             "type": "object",
@@ -381,6 +381,9 @@
                                     "type": "string"
                                 }
                             }
+                        },
+                        "labels": {
+                            "type": "object"
                         },
                         "nodePorts": {
                             "type": "object",
@@ -457,6 +460,9 @@
                 },
                 "userID": {
                     "type": "integer"
+                },
+                "watchIngressWithoutClass": {
+                    "type": "boolean"
                 }
             }
         },

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -200,9 +200,15 @@ controller:
   # Example value: "default/foo-tls".
   defaultSSLCertificate: ""
 
-  # controller.ingressClass
-  # The Ingress class, which the controller handles.
-  ingressClass: nginx
+  # controller.ingressClassResource
+  # This section refers to the creation of the IngressClass resource
+  # IngressClass resources are supported since k8s >= 1.18 and required since k8s >= 1.19
+  ingressClassResource:
+    name: nginx
+    enabled: true
+    default: false
+    controllerValue: "k8s.io/ingress-nginx"
+    parameters: {}
 
   # controller.userID
   # The userID that the container will run as. 101 is the www-data user.

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -79,7 +79,7 @@ controller:
 
     # controller.image.tag
     # When updating tag make sure to also keep appVersion in Chart.yaml in sync
-    tag: v0.49.0
+    tag: v1.0.0
 
   # controller.containerPort
   containerPort:
@@ -364,6 +364,11 @@ controller:
   # Enable or disable forwarding to ExternalName Services through
   # --disable-svc-external-name flag
   disableExternalNameForwarding: true
+
+  # Process Ingress objects without ingressClass annotation/ingressClassName field
+  # Overrides value for --watch-ingress-without-class flag of the controller binary
+  # Defaults to false
+  watchIngressWithoutClass: false
 
 # image
 image:

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -208,7 +208,10 @@ controller:
     enabled: true
     default: false
     controllerValue: "k8s.io/ingress-nginx"
-    parameters: {}
+    # parameters:
+    #   apiGroup: ""
+    #   kind: ""
+    #   name: ""
 
   # controller.userID
   # The userID that the container will run as. 101 is the www-data user.

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -412,15 +412,6 @@ ingressController:
   controlPlane: false
   configmap: {}
 
-# test
-test:
-
-  # test.image
-  image:
-    registry: quay.io
-    repository: giantswarm/alpine-testing
-    tag: 0.1.0
-
 
 # Below are configuration values that you should not overwrite or set yourself.
 

--- a/test/kind_config.yaml
+++ b/test/kind_config.yaml
@@ -13,3 +13,7 @@ nodes:
     hostPort: 8080
     listenAddress: "127.0.0.1"
     protocol: TCP
+  - containerPort: 30012
+    hostPort: 8081
+    listenAddress: "127.0.0.1"
+    protocol: TCP


### PR DESCRIPTION
This PR updates the nginx-ingress-controller-app to use upstream version 1.0.0. It will become Version 2.2.0 of the app.

Important changes:

- Installs a `IngressClass`
- Only works on k8s >= 1.19
- Only works with `Ingress` in version `networking.k8s.io/v1`