### PR TITLE
do not pin upgrade tests to 2.1.0

### DIFF
--- a/.ats/main.yaml
+++ b/.ats/main.yaml
@@ -8,6 +8,5 @@ functional-tests-cluster-config-file: tests/kind_config.yaml
 
 upgrade-tests-cluster-type: kind
 upgrade-tests-cluster-config-file: tests/kind_config.yaml
-upgrade-tests-app-catalog-url: https://giantswarm.github.io/default-catalog/
-upgrade-tests-app-version: 2.1.0
+upgrade-tests-app-catalog-url: https://giantswarm.github.io/default-catalog
 upgrade-tests-app-config-file: tests/test-values.yaml


### PR DESCRIPTION
This PR removes the `2.1.0` version from upgrade tests