### PR TITLE
Use upstream ingress controller version 1.1.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 this PR has been submitted.
 -->
 
-### Tests on workload clusters
+### Tests on workload clusters (not always required)
 
 In order to verify that my changes also work on, I did the following tests:
 
@@ -22,6 +22,13 @@ In order to verify that my changes also work on, I did the following tests:
 - [ ] Fresh Ingress resources are reconciled correctly
 
 #### KVM
+
+Hint:
+
+```
+kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
+curl -H "Host: host.configured.in.ingress" localhost:8080
+```
 
 - [ ] Upgrade from previous version works
 - [ ] Existing Ingress resources are reconciled correctly (change domain, see if its available)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Update controller container image to [`v1.0.5`](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#105). ([#246](https://github.com/giantswarm/nginx-ingress-controller-app/pull/246))
+- Update controller container image to [`v1.1.0`](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#110). ([#246](https://github.com/giantswarm/nginx-ingress-controller-app/pull/246))
 
 ## [2.4.1] - 2021-10-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Update controller container image to [`v1.0.5`](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#105). ([#246](https://github.com/giantswarm/nginx-ingress-controller-app/pull/246))
+
 ## [2.4.1] - 2021-10-22
 
 ### Changed

--- a/helm/nginx-ingress-controller-app/Chart.yaml
+++ b/helm/nginx-ingress-controller-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v1.0.5
+appVersion: v1.1.0
 description: The most popular ingress controller for Kubernetes, based on NGINX
 home: https://github.com/giantswarm/nginx-ingress-controller-app
 icon: https://s.giantswarm.io/app-icons/1/png/nginx-ingress-controller-app-light.png

--- a/helm/nginx-ingress-controller-app/Chart.yaml
+++ b/helm/nginx-ingress-controller-app/Chart.yaml
@@ -1,10 +1,12 @@
 apiVersion: v1
-appVersion: v1.0.4
+appVersion: v1.0.5
 description: The most popular ingress controller for Kubernetes, based on NGINX
 home: https://github.com/giantswarm/nginx-ingress-controller-app
 icon: https://s.giantswarm.io/app-icons/1/png/nginx-ingress-controller-app-light.png
 kubeVersion: ">=1.19.0-0"
 name: nginx-ingress-controller-app
-version: 2.4.0
+version: 2.5.0
 sources:
   - https://github.com/kubernetes/ingress-nginx/
+annotations:
+  application.giantswarm.io/team: team-cabbage

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -79,7 +79,7 @@ controller:
 
     # controller.image.tag
     # When updating tag make sure to also keep appVersion in Chart.yaml in sync
-    tag: v1.0.5
+    tag: v1.1.0
 
   # controller.containerPort
   containerPort:

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -79,7 +79,7 @@ controller:
 
     # controller.image.tag
     # When updating tag make sure to also keep appVersion in Chart.yaml in sync
-    tag: v1.0.4
+    tag: v1.0.5
 
   # controller.containerPort
   containerPort:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/19834

This PR upgrades to upstream 1.1.0

### Tests on workload clusters

In order to verify that my changes also work on, I did the following tests:

#### AWS

- [x] Upgrade from previous version works
- [x] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [x] Fresh install works
- [x] Fresh Ingress resources are reconciled correctly

#### Azure

- [x] Upgrade from previous version works
- [x] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [x] Fresh install works
- [x] Fresh Ingress resources are reconciled correctly

#### KVM

- [x] Upgrade from previous version works
- [x] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [x] Fresh install works
- [x] Fresh Ingress resources are reconciled correctly
