### PR TITLE
Update aws-load-balancer annotations for internal cluster use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Augment monitoring annotations to have a stable name for monitoring. ([#263](https://github.com/giantswarm/nginx-ingress-controller-app/pull/263))
 - Update aws-load-balancer annotations for internal cluster use.
 - Add required external-dns annotation to internal controller service.
+- Add documentation for service configuration.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Allow disabling external-dns annotations.
 - Update aws-load-balancer annotations for internal cluster use.
+- Add required external-dns annotation to internal controller service.
 
 ## [2.6.1] - 2021-12-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 
 - Allow disabling external-dns annotations.
+- Update aws-load-balancer annotations for internal cluster use.
 
 ## [2.6.1] - 2021-12-03
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,40 @@ facilitate this process.
 
 All configuration options are documented in the [values.yaml](/helm/nginx-ingress-controller-app/values.yaml) file.
 
+### Internal nginx IC options
+
+This chart contains a template for an additional [internal service](helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml) to cover the use case of having separate internal and external ingress routes with a single nginx IC instance. 
+
+Valid configuration options are as follows: 
+
+**Only external (default)**
+
+This is the default behavior. No additional configuration required.
+
+ **Make default service internal**
+
+This configures the [default service](helm/nginx-ingress-controller-app/templates/controller-service.yaml) to spawn an internal facing load balancer. This disables the external ingress.
+ ```yaml
+controller:
+  service:
+    public: false
+ ```
+
+ **Create additional internal service**
+
+This enables the additional internal service template which creates an internal facing load balancer.
+
+```yaml
+controller:
+  service:
+    internal:
+      enabled: true
+```
+
+Other possible configurations are:
+- Two internal load balancer
+- Disable default service completely `controller.service.enabled: false`
+
 ## Limitations
 
 Some of our apps have certain restrictions on how they can be deployed.

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -5,6 +5,9 @@ metadata:
   annotations:
   {{- if .Values.controller.service.externalDNS.enabled }}
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.controller.service.internal.subdomain }}.{{ .Values.baseDomain }}
+    {{- if .Values.controller.service.externalDNS.annotation }}
+    {{ .Values.controller.service.externalDNS.annotation }}
+    {{- end }}
   {{- end }}
   {{- if eq .Values.controller.service.internal.type "LoadBalancer" }}
   {{- if eq .Values.provider "aws" }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -8,7 +8,8 @@ metadata:
   {{- end }}
   {{- if eq .Values.controller.service.internal.type "LoadBalancer" }}
   {{- if eq .Values.provider "aws" }}
-    service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
     {{- if index .Values.configmap "use-proxy-protocol" }}
     service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
     {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -15,7 +15,8 @@ metadata:
   {{- if eq .Values.controller.service.type "LoadBalancer" }}
   {{- if eq .Values.provider "aws" }}
     {{- if not .Values.controller.service.public }}
-    service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
     {{- end }}
     {{- if index .Values.configmap "use-proxy-protocol" }}
     service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'


### PR DESCRIPTION
This PR updates the annotations on services for internal usage.

<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

In order to verify that my changes also work on, I did the following tests:

#### AWS

- [ ] Upgrade from previous version works
- [ ] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [ ] Fresh install works
- [ ] Fresh Ingress resources are reconciled correctly

#### Azure

- [ ] Upgrade from previous version works
- [ ] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [ ] Fresh install works
- [ ] Fresh Ingress resources are reconciled correctly

#### KVM

Hint:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
curl -H "Host: host.configured.in.ingress" localhost:8080
```

- [ ] Upgrade from previous version works
- [ ] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [ ] Fresh install works
- [ ] Fresh Ingress resources are reconciled correctly
