### PR TITLE
Augment monitoring annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 
 - Allow disabling external-dns annotations.
+- Augment monitoring annotations to have a stable name for monitoring. ([#263](https://github.com/giantswarm/nginx-ingress-controller-app/pull/263))
 
 ## [2.6.1] - 2021-12-03
 

--- a/helm/nginx-ingress-controller-app/templates/controller-metrics-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-metrics-service.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     giantswarm.io/monitoring-path: /metrics
     giantswarm.io/monitoring-port: {{ .Values.controller.metrics.port | quote }}
+    giantswarm.io/monitoring-app-label: {{ .Chart.Name | quote }}
     prometheus.io/port: {{ .Values.controller.metrics.port | quote }}
     prometheus.io/scrape: "true"
   labels:


### PR DESCRIPTION
This PR adds the `giantswarm.io/monitoring-app-label` annotaion to the metrics service. Towards https://github.com/giantswarm/roadmap/issues/601 https://github.com/giantswarm/giantswarm/issues/20023