### PR TITLE
Swap kube-webhook-certgen image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Update controller container image to [`v1.1.1`](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#111). ([#264](https://github.com/giantswarm/nginx-ingress-controller-app/pull/264))
-- Swap kube-webhook-certgen container image for ingress-nginx one
+- Swap kube-webhook-certgen container image for ingress-nginx image to ensure compatibility with kubernetes >= 1.22 ([#265]((https://github.com/giantswarm/nginx-ingress-controller-app/pull/264)))
 
 ## [2.6.1] - 2021-12-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Update controller container image to [`v1.1.1`](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#111). ([#264](https://github.com/giantswarm/nginx-ingress-controller-app/pull/264))
+- Swap kube-webhook-certgen container image for ingress-nginx one
 
 ## [2.6.1] - 2021-12-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Update controller container image to [`v1.1.1`](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#111). ([#264](https://github.com/giantswarm/nginx-ingress-controller-app/pull/264))
-- Swap kube-webhook-certgen container image for ingress-nginx image to ensure compatibility with kubernetes >= 1.22 ([#265]((https://github.com/giantswarm/nginx-ingress-controller-app/pull/264)))
+- Swap kube-webhook-certgen container image for ingress-nginx image to ensure compatibility with kubernetes >= 1.22 ([#265](https://github.com/giantswarm/nginx-ingress-controller-app/pull/264))
 
 ## [2.6.1] - 2021-12-03
 

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -335,8 +335,8 @@ controller:
     patch:
       enabled: true
       image:
-        repository: giantswarm/kube-webhook-certgen
-        tag: v1.5.2
+        repository: giantswarm/ingress-nginx-kube-webhook-certgen
+        tag: v1.1.1
       backoffLimit: 6
       priorityClassName: ""
       podAnnotations: {}


### PR DESCRIPTION
This PR changes the kube-webhook-certgen container image with the one used by the upstream ingress-nginx helm chart.

This is to ensure compatibility with kubernetes 1.22
