### PR TITLE
Push chart to control plane catalog.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ workflows:
           app_catalog_test: "control-plane-test-catalog"
           chart: "nginx-ingress-controller-app"
           executor: "app-build-suite"
-          persist_chart_archive: true
+          persist_chart_archive: false
           filters:
             # Trigger the job also on git tag.
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,18 @@ workflows:
             tags:
               only: /^v.*/
 
+      - architect/push-to-app-catalog:
+          name: push-to-control-plane-app-catalog
+          app_catalog: "control-plane-catalog"
+          app_catalog_test: "control-plane-test-catalog"
+          chart: "nginx-ingress-controller-app"
+          executor: "app-build-suite"
+          persist_chart_archive: true
+          filters:
+            # Trigger the job also on git tag.
+            tags:
+              only: /^v.*/
+
       # deploy to openstack installations (only tags)
       - architect/push-to-app-collection:
           name: push-to-openstack-app-collection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Push chart to control plane catalog.
+
 ## [2.7.0] - 2022-01-19
 
 ### Added


### PR DESCRIPTION
Push to control plane catalog to use the app from MCs as well

### Tests on workload clusters (not always required)

In order to verify that my changes also work on, I did the following tests:

#### AWS

- [ ] Upgrade from previous version works
- [ ] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [ ] Fresh install works
- [ ] Fresh Ingress resources are reconciled correctly

#### Azure

- [ ] Upgrade from previous version works
- [ ] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [ ] Fresh install works
- [ ] Fresh Ingress resources are reconciled correctly

#### KVM

Hint:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
curl -H "Host: host.configured.in.ingress" localhost:8080
```

- [ ] Upgrade from previous version works
- [ ] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [ ] Fresh install works
- [ ] Fresh Ingress resources are reconciled correctly
