### PR TITLE
Disable `use-forwarded-headers` by default

### DIFF
--- a/.ats/main.yaml
+++ b/.ats/main.yaml
@@ -8,5 +8,5 @@ functional-tests-cluster-config-file: tests/kind_config.yaml
 
 upgrade-tests-cluster-type: kind
 upgrade-tests-cluster-config-file: tests/kind_config.yaml
-upgrade-tests-app-catalog-url: https://giantswarm.github.io/default-catalog
+upgrade-tests-app-catalog-url: https://giantswarm.github.io/giantswarm-catalog
 upgrade-tests-app-config-file: tests/test-values.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+This release contains a potential breaking change in case you are using and relying on the configuration setting `use-forwarded-headers`. From now on the default value will change to `false`. When you need this to be true override this in your customized values.
+
 ### Changed
 
 - Push chart to control plane catalog.
+- Disable `use-forwarded-headers` by default.
 
 ## [2.7.0] - 2022-01-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-This release contains a potential breaking change in case you are using and relying on the configuration setting `use-forwarded-headers`. From now on the default value will change to `false`. When you need this to be true override this in your customized values.
+This release contains a potential breaking change in case you are using and relying on the configuration setting [`use-forwarded-headers`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#use-forwarded-headers). From now on the default value will change to `false`. In case you're relying on this feature, you'll need override this in your customized values like this:
+
+    configmap:
+        use-forwarded-headers: "true"
+
 
 ### Changed
 

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -44,7 +44,7 @@ configmap:
 
   # configmap.use-forwarded-headers
   # If true, NGINX passes the incoming X-Forwarded-* headers to upstreams.
-  use-forwarded-headers: "true"
+  use-forwarded-headers: "false"
 
 # controller
 # Contains mostly configuration values that get applied to the kubernetes


### PR DESCRIPTION
Changelog entry:
> This release contains a potential breaking change in case you are using and relying on the configuration setting [`use-forwarded-headers`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#use-forwarded-headers). From now on the default value will change to `false`. In case you're relying on this feature, you'll need override this in your customized values like this:
>
>     configmap:
>          use-forwarded-headers: "true"

Tests and questioning customers already are already done by @ubergesundheit 