### PR TITLE
Allow enabling the `enable-ssl-chain-completion` flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Allow enabling the `enable-ssl-chain-completion` flag. Disabled by default.
+
 ## [2.8.0] - 2022-01-27
 
 This release contains a potential breaking change in case you are using and relying on the configuration setting [`use-forwarded-headers`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#use-forwarded-headers). From now on the default value will change to `false`. In case you're relying on this feature, you'll need override this in your customized values like this:

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -91,7 +91,7 @@ spec:
         {{- if .Values.controller.defaultSSLCertificate }}
         - --default-ssl-certificate={{ .Values.controller.defaultSSLCertificate }}
         {{- end}}
-        - --enable-ssl-chain-completion=false
+        - --enable-ssl-chain-completion={{ .Values.controller.enableSSLChainCompletion }}
         - --controller-class={{ .Values.controller.ingressClassResource.controllerValue }}
         {{- if .Values.controller.service.enabled }}
         - --publish-service={{ .Release.Namespace }}/{{ include "resource.controller-service.name" . }}

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -161,6 +161,9 @@
                 "enableMimalloc": {
                     "type": "boolean"
                 },
+                "enableSSLChainCompletion": {
+                    "type": "boolean"
+                },
                 "extraAnnotations": {
                     "type": "object",
                     "properties": {

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -71,6 +71,11 @@ controller:
   # ready before a rolling upgrade can proceed with the next replica.
   minReadySeconds: 0
 
+  # controller.enableSSLChainCompletion
+  # Autocomplete SSL certificate chains with missing intermediate CA certificates.
+  # Certificates uploaded to Kubernetes must have the "Authority Information Access" X.509 v3 extension for this to succeed.
+  enableSSLChainCompletion: false
+
   # controller.image
   image:
 


### PR DESCRIPTION
After upgrading to latest version of the IC in `viking` the ingress endpoints started having SSL errors.
In viking we use customer provided certificates that lack the intermediate chain.
The reason why it stopped working during the upgrade is that we changed the value for `enable-ssl-chain-completion` flag to false. Without that feature, the certificates are invalid.

This PR allows the possibility to enable this feature on demand.

### Tests on workload clusters (not always required)

In order to verify that my changes also work on, I did the following tests:

#### AWS

- [ ] Upgrade from previous version works
- [ ] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [ ] Fresh install works
- [ ] Fresh Ingress resources are reconciled correctly

#### Azure

- [ ] Upgrade from previous version works
- [ ] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [ ] Fresh install works
- [ ] Fresh Ingress resources are reconciled correctly

#### KVM

Hint:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
curl -H "Host: host.configured.in.ingress" localhost:8080
```

- [ ] Upgrade from previous version works
- [ ] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [ ] Fresh install works
- [ ] Fresh Ingress resources are reconciled correctly
