### PR TITLE
Make maxSurge configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Added `maxSurge` parameter to values for the controller deployment strategy.
+
 ## [2.9.0] - 2022-02-10
 
 ### Added

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -23,7 +23,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
+      maxSurge: {{ .Values.controller.maxSurge }}
       maxUnavailable: {{ .Values.controller.maxUnavailable }}
   minReadySeconds: {{ .Values.controller.minReadySeconds }}
   template:

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -267,6 +267,9 @@
                         }
                     }
                 },
+                "maxSurge": {
+                    "type": "integer"
+                },
                 "maxUnavailable": {
                     "type": "integer"
                 },

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -60,6 +60,11 @@ controller:
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
   antiAffinityScheduling: preferredDuringSchedulingIgnoredDuringExecution
 
+  # controller.maxSurge
+  # Configures maximum number of replicas that can be created over 
+  # the desired number of Pods.
+  maxSurge: 1
+
   # controller.maxUnavailable
   # Configures maximum number of unavailable replicas while doing a
   # rolling upgrade.

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -61,7 +61,7 @@ controller:
   antiAffinityScheduling: preferredDuringSchedulingIgnoredDuringExecution
 
   # controller.maxSurge
-  # Configures maximum number of replicas that can be created over 
+  # Configures maximum number of replicas that can be created over
   # the desired number of Pods.
   maxSurge: 1
 


### PR DESCRIPTION
Towards a request made by a customer today in support 

<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

In order to verify that my changes also work on, I did the following tests:

#### AWS

- [x] Upgrade from previous version works
- [x] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [x] Fresh install works
- [x] Fresh Ingress resources are reconciled correctly

#### Azure

- [x] Upgrade from previous version works
- [x] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [x] Fresh install works
- [x] Fresh Ingress resources are reconciled correctly

#### KVM

Hint:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
curl -H "Host: host.configured.in.ingress" localhost:8080
```

- [x] Upgrade from previous version works
- [x] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [x] Fresh install works
- [x] Fresh Ingress resources are reconciled correctly
