### PR TITLE
Bump used container version to 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Update controller container image to [`v1.1.2`](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#112)
+
 ## [2.9.1] - 2022-02-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Update controller container image to [`v1.1.2`](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#112)
+- Update controller container image to [`v1.1.2`](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#112) ([#287](https://github.com/giantswarm/nginx-ingress-controller-app/pull/287))
 
 ## [2.9.1] - 2022-02-23
 

--- a/helm/nginx-ingress-controller-app/Chart.yaml
+++ b/helm/nginx-ingress-controller-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v1.1.1
+appVersion: v1.1.2
 description: The most popular ingress controller for Kubernetes, based on NGINX
 home: https://github.com/giantswarm/nginx-ingress-controller-app
 icon: https://s.giantswarm.io/app-icons/1/png/nginx-ingress-controller-app-light.png

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -89,7 +89,7 @@ controller:
 
     # controller.image.tag
     # When updating tag make sure to also keep appVersion in Chart.yaml in sync
-    tag: v1.1.1
+    tag: v1.1.2
 
   # controller.containerPort
   containerPort:


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

In order to verify that my changes also work on, I did the following tests:

#### AWS

- [ ] Upgrade from previous version works
- [ ] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [ ] Fresh install works
- [ ] Fresh Ingress resources are reconciled correctly

#### Azure

- [ ] Upgrade from previous version works
- [ ] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [ ] Fresh install works
- [ ] Fresh Ingress resources are reconciled correctly

#### KVM

Hint:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
curl -H "Host: host.configured.in.ingress" localhost:8080
```

- [ ] Upgrade from previous version works
- [ ] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [ ] Fresh install works
- [ ] Fresh Ingress resources are reconciled correctly
