### PR TITLE
Fix: Reduce resource requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Reduced default resource requests to upstream values.
+- Reduced default resource requests to former profile `small` and let HPA care about scaling.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Reduced default resource requests to former profile `small` and let HPA care about scaling.
+- Reduced default resource requests to former profile `small` (at least 500m of CPU and 600Mi of memory) and let HPA care about scaling.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Reduced default resource requests to upstream values.
+
+### Removed
+
+- Support for `cluster.profile` parameter. This parameter was not set on either management clusters nor workload clusters and so the default resource requests configured in `controller.resources` got used.
+
 ## [2.11.0] - 2022-04-22
 
 ### Changed

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -136,9 +136,9 @@ spec:
         {{- if .Values.controller.extraEnvs }}
           {{- toYaml .Values.controller.extraEnvs | nindent 8 }}
         {{- end }}
-        {{- if .Values.controller.resources }}
+        {{- with .Values.controller.resources }}
         resources:
-{{ toYaml .Values.controller.resources | indent 10 }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- if .Values.controller.livenessProbe.enabled }}
         livenessProbe:

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -136,15 +136,9 @@ spec:
         {{- if .Values.controller.extraEnvs }}
           {{- toYaml .Values.controller.extraEnvs | nindent 8 }}
         {{- end }}
-        {{- if .Values.cluster.profile }}
-        {{- if gt (.Values.cluster.profile | int) 2 }}
+        {{- if .Values.controller.resources }}
         resources:
-          {{- if eq (.Values.cluster.profile | toString) "3" }}
-{{ toYaml .Values.controller.profile.small.resources | indent 10 }}
-          {{- else }}
 {{ toYaml .Values.controller.resources | indent 10 }}
-          {{- end }}
-        {{- end }}
         {{- end }}
         {{- if .Values.controller.livenessProbe.enabled }}
         livenessProbe:

--- a/helm/nginx-ingress-controller-app/templates/controller-hpa.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-hpa.yaml
@@ -1,4 +1,3 @@
-{{- if gt (.Values.cluster.profile | int) 2 }}
 {{- if .Values.controller.autoscaling.enabled }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
@@ -27,5 +26,4 @@ spec:
         name: memory
         targetAverageUtilization: {{ . }}
     {{- end }}
-{{- end }}
 {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/controller-poddisruptionbudget.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if or (and (gt (.Values.cluster.profile | int) 2) (and .Values.controller.autoscaling.enabled (gt (.Values.controller.autoscaling.minReplicas | int) 1))) (gt (.Values.controller.replicaCount | int) 1) }}
+{{- if or (and .Values.controller.autoscaling.enabled (gt (.Values.controller.autoscaling.minReplicas | int) 1)) (gt (.Values.controller.replicaCount | int) 1) }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -5,14 +5,6 @@
         "baseDomain": {
             "type": "string"
         },
-        "cluster": {
-            "type": "object",
-            "properties": {
-                "profile": {
-                    "type": "integer"
-                }
-            }
-        },
         "clusterID": {
             "type": "string"
         },
@@ -294,32 +286,6 @@
                 },
                 "minReadySeconds": {
                     "type": "integer"
-                },
-                "profile": {
-                    "type": "object",
-                    "properties": {
-                        "small": {
-                            "type": "object",
-                            "properties": {
-                                "resources": {
-                                    "type": "object",
-                                    "properties": {
-                                        "requests": {
-                                            "type": "object",
-                                            "properties": {
-                                                "cpu": {
-                                                    "type": ["string", "integer"]
-                                                },
-                                                "memory": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
                 },
                 "readinessProbe": {
                     "type": "object",

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -150,8 +150,8 @@ controller:
     # controller.resources.requests
     # These are default resource requests.
     requests:
-      cpu: 100m
-      memory: 90Mi
+      cpu: 500m
+      memory: 600Mi
 
   # controller.terminationGracePeriodSeconds
   # The maximum amount of time NGINX Deployment replica is given to gracefully

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -148,28 +148,10 @@ controller:
   resources:
 
     # controller.resources.requests
-    # These are default resource requests when the cluster profile is not
-    # known or when the cluster is larger than "small"
+    # These are default resource requests.
     requests:
       cpu: 2
       memory: 2.5Gi
-
-  # controller.profile
-  # Contains resource request profiles that could get selected based on the
-  # value of cluster.profile.
-  # A profile is a set of preconfigured values for the
-  # "spec.template.spec.containers.resources.requests" field of the Deployment
-  # resource.
-  profile:
-    # xxs (1) cluster profile - 1 worker node only - resource requests are not being set
-    # xs (2) cluster profile - 2-3 worker nodes, max CPU < 4 - resource requests are not being set
-    # TODO set resource requests same as small once coredns scale and resources are cluster profile adjusted https://github.com/giantswarm/giantswarm/issues/9316
-    # small (3) cluster profile - > 3 worker nodes, max CPU still < 4
-    small:
-      resources:
-        requests:
-          cpu: 500m
-          memory: 600Mi
 
   # controller.terminationGracePeriodSeconds
   # The maximum amount of time NGINX Deployment replica is given to gracefully
@@ -459,18 +441,3 @@ clusterID: uun5a
 # The provider that the cluster is running on.
 # This value is set automatically, Do not overwrite this value.
 provider: aws
-
-# cluster
-cluster:
-
-  # cluster.profile
-  # Supported values are 1 for extra extra small, 2 for extra small, 3 for small,
-  # and currently any value higher than 3 when actual cluster profile is larger
-  # than small or unknown. By default HPA and PDB are disabled, and resource
-  # requests unset for extra extra small clusters and extra small clusters.
-  # On small clusters some small resource requests are made, HPA and PDB are
-  # enabled by default. On larger than small clusters HPA and PDB are enabled by
-  # default, and non-trivial resource requests set for some out-of-the-box
-  # guaranteed capacity.
-  # This value is set automatically. Do not overwrite this value.
-  profile: 4

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -150,8 +150,8 @@ controller:
     # controller.resources.requests
     # These are default resource requests.
     requests:
-      cpu: 2
-      memory: 2.5Gi
+      cpu: 100m
+      memory: 90Mi
 
   # controller.terminationGracePeriodSeconds
   # The maximum amount of time NGINX Deployment replica is given to gracefully

--- a/tests/ats/multi-controller-manifests.yaml
+++ b/tests/ats/multi-controller-manifests.yaml
@@ -19,13 +19,15 @@ data:
         controllerValue: "k8s.io/ingress-nginx2"
       autoscaling:
         enabled: false
+      resources:
+        requests:
+          cpu: 100m
+          memory: 90Mi
       service:
         type: NodePort
         nodePorts:
           http: 30012
           https: 30013
-    cluster:
-      profile: 1
 kind: ConfigMap
 metadata:
   name: second-ingress-controller-cm

--- a/tests/test-values.yaml
+++ b/tests/test-values.yaml
@@ -3,8 +3,10 @@ configmap:
 controller:
   autoscaling:
     enabled: false
+  resources:
+    requests:
+      cpu: 100m
+      memory: 90Mi
   service:
     suffix: "-test"
     type: NodePort
-cluster:
-  profile: 1


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR drops support for cluster profiles since they are not set by either cluster operator nor app operator and therefore the defaults get used. Furthermore it reduces the requests to those from upstream.

Resolves https://github.com/giantswarm/giantswarm/issues/21735.

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version |  |  |  |
| Existing Ingress resources are reconciled correctly |  |  |  |
| Fresh install |  |  |  |
| Fresh Ingress resources are reconciled correctly |  |  |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```