### PR TITLE
Update used container image to v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Update controller container image to [`v1.2.1`](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#121) which removes the root and alias directives from the internal NGIXN. ([#311](https://github.com/giantswarm/nginx-ingress-controller-app/pull/311))
+- Update controller container image to [`v1.2.1`](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#121) which removes the root and alias directives from the internal NGINX. ([#311](https://github.com/giantswarm/nginx-ingress-controller-app/pull/311))
 
 ## [2.12.0] - 2022-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Update controller container image to [`v1.2.1`](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#121) which removes the root and alias directives from the internal NGIXN. ([#311](https://github.com/giantswarm/nginx-ingress-controller-app/pull/311))
+
 ## [2.12.0] - 2022-05-13
 
 ### Changed

--- a/helm/nginx-ingress-controller-app/Chart.yaml
+++ b/helm/nginx-ingress-controller-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v1.2.0
+appVersion: v1.2.1
 description: The most popular ingress controller for Kubernetes, based on NGINX
 home: https://github.com/giantswarm/nginx-ingress-controller-app
 icon: https://s.giantswarm.io/app-icons/1/png/nginx-ingress-controller-app-light.png

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -89,7 +89,7 @@ controller:
 
     # controller.image.tag
     # When updating tag make sure to also keep appVersion in Chart.yaml in sync
-    tag: v1.2.0
+    tag: v1.2.1
 
   # controller.containerPort
   containerPort:


### PR DESCRIPTION
This PR updates the used container image version to [v1.2.1](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.2.1). It mainly contains the removal of nginx [`root`](https://nginx.org/en/docs/http/ngx_http_core_module.html#root) and [`alias`](https://nginx.org/en/docs/http/ngx_http_core_module.html#alias) directives which are not used by the ingress controller because it only proxies.
