### PR TITLE
helm/deployment: Add topologySpreadConstraints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Optional: Topology spread constraints for pod assignment (requires Kubernetes >= 1.19). Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints. Important: We strongly suggest you review these settings before applying onto your clusters. This document https://docs.giantswarm.io/advanced/high-availability/multi-az/ gives more insight.
+
 ## [2.12.1] - 2022-06-09
 
 ### Changed

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -53,9 +53,9 @@ spec:
                   values:
                   - {{ .Release.Name | quote }}
               topologyKey: kubernetes.io/hostname
-      {{- if .Values.topologySpreadConstraints }}
+      {{- if .Values.controller.topologySpreadConstraints }}
       topologySpreadConstraints:
-      {{- tpl .Values.topologySpreadConstraints . | indent 6 }}
+      {{- tpl .Values.controller.topologySpreadConstraints . | indent 6 }}
       {{- end }}
       serviceAccountName: {{ include "resource.default.name"  . }}
       priorityClassName: system-cluster-critical

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -55,7 +55,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       {{- if .Values.controller.topologySpreadConstraints }}
       topologySpreadConstraints:
-      {{- tpl .Values.controller.topologySpreadConstraints . | indent 6 }}
+{{ tpl .Values.controller.topologySpreadConstraints . | indent 6 }}
       {{- end }}
       serviceAccountName: {{ include "resource.default.name"  . }}
       priorityClassName: system-cluster-critical

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -53,6 +53,10 @@ spec:
                   values:
                   - {{ .Release.Name | quote }}
               topologyKey: kubernetes.io/hostname
+      {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- tpl .Values.topologySpreadConstraints . | indent 6 }}
+      {{- end }}
       serviceAccountName: {{ include "resource.default.name"  . }}
       priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -113,6 +113,9 @@
                 "antiAffinityScheduling": {
                     "type": "string"
                 },
+                "topologySpreadConstraints": {
+                    "type": "string"
+                },
                 "autoscaling": {
                     "type": "object",
                     "properties": {

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -71,6 +71,7 @@ controller:
   #       matchLabels:
   #         app.kubernetes.io/name: {{ include "name" . | quote }}
   #         app.kubernetes.io/instance: {{ .Release.Name | quote }}
+  #         app.kubernetes.io/component: controller
   #     topologyKey: topology.kubernetes.io/zone
   #     maxSkew: 1
   #     whenUnsatisfiable: ScheduleAnyway
@@ -78,6 +79,7 @@ controller:
   #       matchLabels:
   #         app.kubernetes.io/name: {{ include "name" . | quote }}
   #         app.kubernetes.io/instance: {{ .Release.Name | quote }}
+  #         app.kubernetes.io/component: controller
   #     topologyKey: kubernetes.io/hostname
   #     maxSkew: 1
   #     whenUnsatisfiable: ScheduleAnyway

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -60,6 +60,28 @@ controller:
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
   antiAffinityScheduling: preferredDuringSchedulingIgnoredDuringExecution
 
+  # controller.topologySpreadConstraints
+  # Topology spread constraints for pod assignment (requires Kubernetes >= 1.19)
+  # Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  # Important: We strongly suggest you review these settings before applying onto your clusters.
+  # This document https://docs.giantswarm.io/advanced/high-availability/multi-az/ gives more insight.
+  topologySpreadConstraints: ""
+  #topologySpreadConstraints: |-
+  #  - labelSelector:
+  #      matchLabels:
+  #        app.kubernetes.io/name: {{ include "name" . | quote }}
+  #        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+  #    topologyKey: topology.kubernetes.io/zone
+  #    maxSkew: 1
+  #    whenUnsatisfiable: ScheduleAnyway
+  #  - labelSelector:
+  #      matchLabels:
+  #        app.kubernetes.io/name: {{ include "name" . | quote }}
+  #        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+  #    topologyKey: kubernetes.io/hostname
+  #    maxSkew: 1
+  #    whenUnsatisfiable: ScheduleAnyway
+
   # controller.maxSurge
   # Configures maximum number of replicas that can be created over
   # the desired number of Pods.

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -66,21 +66,21 @@ controller:
   # Important: We strongly suggest you review these settings before applying onto your clusters.
   # This document https://docs.giantswarm.io/advanced/high-availability/multi-az/ gives more insight.
   topologySpreadConstraints: ""
-  #topologySpreadConstraints: |-
-  #  - labelSelector:
-  #      matchLabels:
-  #        app.kubernetes.io/name: {{ include "name" . | quote }}
-  #        app.kubernetes.io/instance: {{ .Release.Name | quote }}
-  #    topologyKey: topology.kubernetes.io/zone
-  #    maxSkew: 1
-  #    whenUnsatisfiable: ScheduleAnyway
-  #  - labelSelector:
-  #      matchLabels:
-  #        app.kubernetes.io/name: {{ include "name" . | quote }}
-  #        app.kubernetes.io/instance: {{ .Release.Name | quote }}
-  #    topologyKey: kubernetes.io/hostname
-  #    maxSkew: 1
-  #    whenUnsatisfiable: ScheduleAnyway
+  # topologySpreadConstraints: |-
+  #   - labelSelector:
+  #       matchLabels:
+  #         app.kubernetes.io/name: {{ include "name" . | quote }}
+  #         app.kubernetes.io/instance: {{ .Release.Name | quote }}
+  #     topologyKey: topology.kubernetes.io/zone
+  #     maxSkew: 1
+  #     whenUnsatisfiable: ScheduleAnyway
+  #   - labelSelector:
+  #       matchLabels:
+  #         app.kubernetes.io/name: {{ include "name" . | quote }}
+  #         app.kubernetes.io/instance: {{ .Release.Name | quote }}
+  #     topologyKey: kubernetes.io/hostname
+  #     maxSkew: 1
+  #     whenUnsatisfiable: ScheduleAnyway
 
   # controller.maxSurge
   # Configures maximum number of replicas that can be created over


### PR DESCRIPTION
This PR adds support for topologySpreadConstraints.

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version |  |  |  |
| Existing Ingress resources are reconciled correctly |  |  |  |
| Fresh install |  |  |  |
| Fresh Ingress resources are reconciled correctly |  |  |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
