### PR TITLE
helm/values: Enable topologySpreadConstraints by default.

### DIFF
--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -77,24 +77,23 @@ controller:
   # Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
   # Important: We strongly suggest you review these settings before applying onto your clusters.
   # This document https://docs.giantswarm.io/advanced/high-availability/multi-az/ gives more insight.
-  topologySpreadConstraints: ""
-  # topologySpreadConstraints: |-
-  #   - labelSelector:
-  #       matchLabels:
-  #         app.kubernetes.io/name: {{ include "name" . | quote }}
-  #         app.kubernetes.io/instance: {{ .Release.Name | quote }}
-  #         app.kubernetes.io/component: controller
-  #     topologyKey: topology.kubernetes.io/zone
-  #     maxSkew: 1
-  #     whenUnsatisfiable: ScheduleAnyway
-  #   - labelSelector:
-  #       matchLabels:
-  #         app.kubernetes.io/name: {{ include "name" . | quote }}
-  #         app.kubernetes.io/instance: {{ .Release.Name | quote }}
-  #         app.kubernetes.io/component: controller
-  #     topologyKey: kubernetes.io/hostname
-  #     maxSkew: 1
-  #     whenUnsatisfiable: ScheduleAnyway
+  topologySpreadConstraints: |-
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: {{ include "name" . | quote }}
+          app.kubernetes.io/instance: {{ .Release.Name | quote }}
+          app.kubernetes.io/component: controller
+      topologyKey: topology.kubernetes.io/zone
+      maxSkew: 1
+      whenUnsatisfiable: ScheduleAnyway
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: {{ include "name" . | quote }}
+          app.kubernetes.io/instance: {{ .Release.Name | quote }}
+          app.kubernetes.io/component: controller
+      topologyKey: kubernetes.io/hostname
+      maxSkew: 1
+      whenUnsatisfiable: ScheduleAnyway
 
   # controller.maxSurge
   # Configures maximum number of replicas that can be created over


### PR DESCRIPTION
Default values are still some kind of optional since they are using `whenUnsatisfiable: ScheduleAnyway` so pods won't be pending.

<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version |  |  |  |
| Existing Ingress resources are reconciled correctly |  |  |  |
| Fresh install |  |  |  |
| Fresh Ingress resources are reconciled correctly |  |  |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
