### PR TITLE
Remove default basedomain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- externalDNS annotations won't no longer be set on the ingress services if `baseDomain` is not set. ([#321](https://github.com/giantswarm/nginx-ingress-controller-app/pull/321))
+
+### Removed
+
+- Default value for `baseDomain` configuration value automatically set for workload cluster installations. ([#321](https://github.com/giantswarm/nginx-ingress-controller-app/pull/321))
+- Unused configuration values for chart installations on management clusters. ([#321](https://github.com/giantswarm/nginx-ingress-controller-app/pull/321))
+
 ## [2.13.1] - 2022-06-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [2.13.1] - 2022-06-16
 
+### Changed
+
+- Enable topology spread constraints by default. ([#318](https://github.com/giantswarm/nginx-ingress-controller-app/pull/318))
+
 ## [2.13.0] - 2022-06-15
 
 ### Added

--- a/helm/nginx-ingress-controller-app/templates/configmap.yaml
+++ b/helm/nginx-ingress-controller-app/templates/configmap.yaml
@@ -8,6 +8,3 @@ metadata:
 data:
   allow-snippet-annotations: "{{ .Values.controller.allowSnippetAnnotations }}"
   {{- toYaml .Values.configmap | trim | nindent 2 }}
-  {{- if .Values.ingressController.controlPlane }}
-  {{- toYaml .Values.ingressController.configmap | trim | nindent 2 }}
-  {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-  {{- if .Values.controller.service.externalDNS.enabled }}
+  {{- if and .Values.controller.service.externalDNS.enabled .Values.baseDomain }}
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.controller.service.internal.subdomain }}.{{ .Values.baseDomain }}
     {{- if .Values.controller.service.externalDNS.annotation }}
     {{ .Values.controller.service.externalDNS.annotation }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- range $key, $value := .Values.controller.service.annotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
-  {{- if .Values.controller.service.externalDNS.enabled }}
+  {{- if and .Values.controller.service.externalDNS.enabled .Values.baseDomain }}
     external-dns.alpha.kubernetes.io/hostname: "{{ .Values.controller.service.subdomain }}.{{ .Values.baseDomain }}"
     {{- if .Values.controller.service.externalDNS.annotation }}
     {{ .Values.controller.service.externalDNS.annotation }}

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -3,10 +3,7 @@
     "type": "object",
     "properties": {
         "baseDomain": {
-            "type": "string"
-        },
-        "clusterID": {
-            "type": "string"
+            "type": ["null", "string"]
         },
         "configmap": {
             "type": "object",
@@ -111,9 +108,6 @@
                     "type": "string"
                 },
                 "antiAffinityScheduling": {
-                    "type": "string"
-                },
-                "topologySpreadConstraints": {
                     "type": "string"
                 },
                 "autoscaling": {
@@ -473,6 +467,9 @@
                 "terminationGracePeriodSeconds": {
                     "type": "integer"
                 },
+                "topologySpreadConstraints": {
+                    "type": "string"
+                },
                 "updateIngressStatus": {
                     "type": "boolean"
                 },
@@ -489,17 +486,6 @@
             "properties": {
                 "registry": {
                     "type": "string"
-                }
-            }
-        },
-        "ingressController": {
-            "type": "object",
-            "properties": {
-                "configmap": {
-                    "type": "object"
-                },
-                "controlPlane": {
-                    "type": "boolean"
                 }
             }
         },

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -446,31 +446,12 @@ initContainer:
 podSecurityPolicy:
   enabled: true
 
-# ingressController.controlPlane
-# Defines if this app is installed into management-cluster.
-#
-# ingressController.configmap
-# These values get applied directly to a configmap which configures the
-# nginx-ingress-controller
-# For all the nginx configmap config options see:
-# https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#configmaps
-# This is used  for management-cluster specific configuration, which can be applied via control-plane catalog.
-ingressController:
-  controlPlane: false
-  configmap: {}
-
-
 # Below are configuration values that you should not overwrite or set yourself.
 
 # baseDomain
 # The base domain for this ingress.
 # This value is set automatically. Do not overwrite this value.
-baseDomain: uun5a.k8s.ginger.eu-central-1.aws.gigantic.io
-
-# clusterID
-# The id of the cluster that this app is installed on.
-# This value is set automatically. Do not overwrite this value.
-clusterID: uun5a
+baseDomain:
 
 # provider (aws|kvm|azure)
 # The provider that the cluster is running on.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/22515

This PR attempts to ease installation of the app on management cluster by

- not applying externalDNS annotations on the ingress services if `baseDomain` is not set.
- removing the default value for `baseDomain` configuration value automatically set for workload cluster installations.
- removing unused configuration values for chart installations on management clusters.
