### PR TITLE
templates/controller-metrics-service: Add labels.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Support for labels on the controller metrics service.
+
 ## [2.15.1] - 2022-08-08
 
 ### Changed

--- a/helm/nginx-ingress-controller-app/templates/controller-metrics-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-metrics-service.yaml
@@ -12,6 +12,9 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
     giantswarm.io/monitoring: "true"
+    {{- with .Values.controller.metrics.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   clusterIP: None
   ports:

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -276,6 +276,9 @@
                             "properties": {
                                 "servicePort": {
                                     "type": "integer"
+                                },
+                                "labels": {
+                                    "type": "object"
                                 }
                             }
                         }

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -178,6 +178,10 @@ controller:
       # controller.metrics.service.servicePort
       # Configures the port that the metrics service is listening on.
       servicePort: 10254
+      
+      # controller.metrics.service.labels
+      # Labels to add to the metrics service.
+      labels: {}
 
   # controller.resources
   resources:

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -178,7 +178,7 @@ controller:
       # controller.metrics.service.servicePort
       # Configures the port that the metrics service is listening on.
       servicePort: 10254
-      
+
       # controller.metrics.service.labels
       # Labels to add to the metrics service.
       labels: {}


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version | ✓ |  |  |
| Existing Ingress resources are reconciled correctly | ✓ |  |  |
| Fresh install | ✓ |  |  |
| Fresh Ingress resources are reconciled correctly | ✓ |  |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
