### PR TITLE
Upgrade controller image version to v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This release removes support for Kubernetes v1.19.0 and adds support for Kuberne
 ### Changed
 
 - Update controller container image to [`v1.3.0`](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#130). ([#335](https://github.com/giantswarm/nginx-ingress-controller-app/pull/335))
+- Increase default replica count to 2. ([#335](https://github.com/giantswarm/nginx-ingress-controller-app/pull/335))
 
 ## [2.15.2] - 2022-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+This release removes support for Kubernetes v1.19.0 and adds support for Kubernetes v1.24.0
+
+### Changed
+
+- Update controller container image to [`v1.3.0`](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#130). ([#335](https://github.com/giantswarm/nginx-ingress-controller-app/pull/335))
+
 ## [2.15.2] - 2022-08-15
 
 ### Added

--- a/helm/nginx-ingress-controller-app/Chart.yaml
+++ b/helm/nginx-ingress-controller-app/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
-appVersion: v1.2.1
+appVersion: v1.3.0
 description: The most popular ingress controller for Kubernetes, based on NGINX
 home: https://github.com/giantswarm/nginx-ingress-controller-app
 icon: https://s.giantswarm.io/app-icons/nginx-ingress-controller/1/light.svg
-kubeVersion: ">=1.19.0-0"
+kubeVersion: ">=1.20.0-0"
 name: nginx-ingress-controller-app
 version: 2.15.2
 sources:

--- a/helm/nginx-ingress-controller-app/templates/rbac.yaml
+++ b/helm/nginx-ingress-controller-app/templates/rbac.yaml
@@ -181,7 +181,7 @@ rules:
   resources:
   - leases
   resourceNames:
-  - {{ .Values.controller.electionID }}
+  - "{{ include "controller.leader.election.id" . }}"
   verbs:
   - get
   - update

--- a/helm/nginx-ingress-controller-app/templates/rbac.yaml
+++ b/helm/nginx-ingress-controller-app/templates/rbac.yaml
@@ -91,6 +91,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -169,6 +176,21 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - {{ .Values.controller.electionID }}
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
 {{- if .Values.podSecurityPolicy.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -124,7 +124,7 @@ controller:
 
     # controller.image.tag
     # When updating tag make sure to also keep appVersion in Chart.yaml in sync
-    tag: v1.2.1
+    tag: v1.3.0
 
   # controller.containerPort
   containerPort:

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -53,7 +53,7 @@ controller:
 
   # controller.replicaCount
   # Number of initial NGINX IC Deployment replicas.
-  replicaCount: 1
+  replicaCount: 2
 
   # controller.antiAffinityScheduling
   # Configures podAntiAffinity scheduling strategy.

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -380,7 +380,7 @@ controller:
       enabled: true
       image:
         repository: giantswarm/ingress-nginx-kube-webhook-certgen
-        tag: v1.1.1
+        tag: v1.3.0
       backoffLimit: 6
       priorityClassName: ""
       podAnnotations: {}

--- a/tests/test-values.yaml
+++ b/tests/test-values.yaml
@@ -1,6 +1,7 @@
 configmap:
   worker-processes: "2"
 controller:
+  replicaCount: 2
   autoscaling:
     enabled: false
   resources:


### PR DESCRIPTION
This PR 

- updates the controller image version to v1.3.0
- changes the default number of replicas to 2

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

- Plain installing works
- Upgrading from previous version works

Testing was done using `hello-world-app`.
