### PR TITLE
templates/service: Make `loadBalancerSourceRanges` configurable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- `controller.service.loadBalancerSourceRanges` & `controller.service.internal.loadBalancerSourceRanges` for configuring source IP address ranges which can access the ingress service.
+
 ## [2.17.0] - 2022-09-13
 
 ### Changed

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -36,9 +36,8 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.controller.service.internal.type }}
-  {{- if eq .Values.controller.service.internal.type "LoadBalancer" }}
-  loadBalancerSourceRanges:
-  - 0.0.0.0/0
+  {{- with .Values.controller.service.internal.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toYaml . | nindent 2 }}
   {{- end }}
   ports:
   - name: http

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -40,9 +40,8 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.controller.service.type }}
-  {{- if eq .Values.controller.service.type "LoadBalancer" }}
-  loadBalancerSourceRanges:
-  - 0.0.0.0/0
+  {{- with .Values.controller.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toYaml . | nindent 2 }}
   {{- end }}
   ports:
   - name: http

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -370,6 +370,9 @@
                                 "labels": {
                                     "type": "object"
                                 },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array"
+                                },
                                 "nodePorts": {
                                     "type": "object",
                                     "properties": {
@@ -405,6 +408,9 @@
                         },
                         "labels": {
                             "type": "object"
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array"
                         },
                         "nodePorts": {
                             "type": "object",

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -304,6 +304,11 @@ controller:
     # Valid values: LoadBalancer, NodePort
     type: LoadBalancer
 
+    # controller.service.loadBalancerSourceRanges
+    # Configures the source IP address ranges which can connect to the service.
+    # By default any source IP address can connect to the service.
+    loadBalancerSourceRanges: []
+
     ports:
       http: 80
       https: 443
@@ -347,6 +352,11 @@ controller:
 
       # controller.service.internal.type
       type: LoadBalancer
+
+      # controller.service.internal.loadBalancerSourceRanges
+      # Configures the source IP address ranges which can connect to the service.
+      # By default any source IP address can connect to the service.
+      loadBalancerSourceRanges: []
 
       ports:
         http: 80

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -306,6 +306,7 @@ controller:
 
     # controller.service.loadBalancerSourceRanges
     # Configures the source IP address ranges which can connect to the service.
+    # Keep in mind that some solutions need to access the service to work properly (e.g. cert-manager & Let's Encrypt).
     # By default any source IP address can connect to the service.
     loadBalancerSourceRanges: []
 
@@ -355,6 +356,7 @@ controller:
 
       # controller.service.internal.loadBalancerSourceRanges
       # Configures the source IP address ranges which can connect to the service.
+      # Keep in mind that some solutions need to access the service to work properly (e.g. cert-manager & Let's Encrypt).
       # By default any source IP address can connect to the service.
       loadBalancerSourceRanges: []
 


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version | ✅ |  |  |
| Existing Ingress resources are reconciled correctly | ✅ |  |  |
| Fresh install | ✅ |  |  |
| Fresh Ingress resources are reconciled correctly | ✅ |  |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
