### PR TITLE
Add validation for externalTrafficPolicy fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Validation for `controller.service.externalTrafficPolicy` and `controller.service.internal.externalTrafficPolicy` to only allow `Local` and `Cluster`. ([#344](https://github.com/giantswarm/nginx-ingress-controller-app/pull/344))
+
 ## [2.18.0] - 2022-09-27
 
 ### Added

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -353,7 +353,8 @@
                             }
                         },
                         "externalTrafficPolicy": {
-                            "type": "string"
+                            "type": "string",
+                            "pattern": "(Local|Cluster)"
                         },
                         "internal": {
                             "type": "object",
@@ -365,7 +366,8 @@
                                     "type": "boolean"
                                 },
                                 "externalTrafficPolicy": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "pattern": "(Local|Cluster)"
                                 },
                                 "labels": {
                                     "type": "object"


### PR DESCRIPTION
This PR adds validation for `controller.service.externalTrafficPolicy` and `controller.service.internal.externalTrafficPolicy` to only allow `Local` and `Cluster`.