### PR TITLE
chart: Update controller container image to `v1.3.1`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Update controller container image to [`v1.3.1`](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#131). ([#349](https://github.com/giantswarm/nginx-ingress-controller-app/pull/349))
+
 ## [2.18.1] - 2022-09-29
 
 ### Added

--- a/helm/nginx-ingress-controller-app/Chart.yaml
+++ b/helm/nginx-ingress-controller-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v1.3.0
+appVersion: v1.3.1
 description: The most popular ingress controller for Kubernetes, based on NGINX
 home: https://github.com/giantswarm/nginx-ingress-controller-app
 icon: https://s.giantswarm.io/app-icons/nginx-ingress-controller/1/light.svg

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -274,11 +274,11 @@
                         "service": {
                             "type": "object",
                             "properties": {
-                                "servicePort": {
-                                    "type": "integer"
-                                },
                                 "labels": {
                                     "type": "object"
+                                },
+                                "servicePort": {
+                                    "type": "integer"
                                 }
                             }
                         }

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -124,7 +124,7 @@ controller:
 
     # controller.image.tag
     # When updating tag make sure to also keep appVersion in Chart.yaml in sync
-    tag: v1.3.0
+    tag: v1.3.1
 
   # controller.containerPort
   containerPort:


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version | ✅ | ✅ |  |
| Existing Ingress resources are reconciled correctly | ✅ | ✅ |  |
| Fresh install | ✅ | ✅ |  |
| Fresh Ingress resources are reconciled correctly | ✅ | ✅ |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
