### PR TITLE
Disable `PodSecurityPolicy` for Kubernetes >= v1.25.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Add support to create internal Load Balancers on GCP.
 
+### Removed
+
+- Disable `PodSecurityPolicy` for Kubernetes >= v1.25. ([#352](https://github.com/giantswarm/nginx-ingress-controller-app/pull/352))
+
 ## [2.18.2] - 2022-10-17
 
 ### Changed

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/psp.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/psp.yaml
@@ -1,3 +1,4 @@
+{{- if (semverCompare "<1.25.0-0" .Capabilities.KubeVersion.Version) }}
 {{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled .Values.podSecurityPolicy.enabled -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -34,4 +35,5 @@ spec:
   - projected
   - secret
   - downwardAPI
+{{- end }}
 {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/psp.yaml
+++ b/helm/nginx-ingress-controller-app/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if (semverCompare "<1.25.0-0" .Capabilities.KubeVersion.Version) }}
 {{- if .Values.podSecurityPolicy.enabled -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -36,4 +37,5 @@ spec:
   volumes:
   - 'secret'
   - 'configMap'
+{{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version |  |  |  |
| Existing Ingress resources are reconciled correctly |  |  |  |
| Fresh install |  |  |  |
| Fresh Ingress resources are reconciled correctly |  |  |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
