### PR TITLE
Update controller container image to `v1.4.0`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Add support to create internal Load Balancers on GCP.
 
+### Changed
+
+- Update controller container image to [`v1.4.0`](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#140). ([#353](https://github.com/giantswarm/nginx-ingress-controller-app/pull/353))
+
 ## [2.18.2] - 2022-10-17
 
 ### Changed

--- a/helm/nginx-ingress-controller-app/Chart.yaml
+++ b/helm/nginx-ingress-controller-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v1.3.1
+appVersion: v1.4.0
 description: The most popular ingress controller for Kubernetes, based on NGINX
 home: https://github.com/giantswarm/nginx-ingress-controller-app
 icon: https://s.giantswarm.io/app-icons/nginx-ingress-controller/1/light.svg

--- a/helm/nginx-ingress-controller-app/templates/rbac.yaml
+++ b/helm/nginx-ingress-controller-app/templates/rbac.yaml
@@ -98,6 +98,14 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -191,6 +199,14 @@ rules:
   - leases
   verbs:
   - create
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+  - get
 {{- if .Values.podSecurityPolicy.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -124,7 +124,7 @@ controller:
 
     # controller.image.tag
     # When updating tag make sure to also keep appVersion in Chart.yaml in sync
-    tag: v1.3.1
+    tag: v1.4.0
 
   # controller.containerPort
   containerPort:
@@ -392,7 +392,7 @@ controller:
       enabled: true
       image:
         repository: giantswarm/ingress-nginx-kube-webhook-certgen
-        tag: v1.3.0
+        tag: v20220916-gd32f8c343
       backoffLimit: 6
       priorityClassName: ""
       podAnnotations: {}


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

Closes https://github.com/giantswarm/giantswarm/issues/23642.

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version | ✅ | ✅ |  |
| Existing Ingress resources are reconciled correctly | ✅ | ✅ |  |
| Fresh install | ✅ | ✅ |  |
| Fresh Ingress resources are reconciled correctly | ✅ | ✅ |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
