### PR TITLE
Add icon to Chart.yml for happa

### DIFF
--- a/helm/nginx-ingress-controller-app/Chart.yaml
+++ b/helm/nginx-ingress-controller-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.4.0
 description: The most popular ingress controller for Kubernetes, based on NGINX
 home: https://github.com/giantswarm/nginx-ingress-controller-app
-icon: https://s.giantswarm.io/app-icons/nginx-ingress-controller/1/light.svg
+icon: https://s.giantswarm.io/app-icons/nginx-ingress-controller/2/icon_dark.svg
 kubeVersion: ">=1.20.0-0"
 name: nginx-ingress-controller-app
 version: 2.18.2
@@ -11,3 +11,4 @@ sources:
 annotations:
   application.giantswarm.io/team: team-cabbage
   config.giantswarm.io/version: 1.x.x
+  ui.giantswarm.io/logo: https://s.giantswarm.io/app-icons/nginx-ingress-controller/2/logo_dark.svg


### PR DESCRIPTION
For https://github.com/giantswarm/roadmap/issues/1248

<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version |  |  |  |
| Existing Ingress resources are reconciled correctly |  |  |  |
| Fresh install |  |  |  |
| Fresh Ingress resources are reconciled correctly |  |  |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
