### PR TITLE
Templates: Add `controller.admissionWebhooks.annotations`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 
 - Templates: Add `controller.admissionWebhooks.patch.labels`. ([#360](https://github.com/giantswarm/nginx-ingress-controller-app/pull/360))
+- Templates: Add `controller.admissionWebhooks.annotations`. ([#362](https://github.com/giantswarm/nginx-ingress-controller-app/pull/362))
 
 ### Changed
 

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -7,6 +7,9 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- with .Values.controller.admissionWebhooks.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -7,6 +7,9 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- with .Values.controller.admissionWebhooks.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/validating-webhook.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/validating-webhook.yaml
@@ -5,6 +5,9 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ include "ingress-nginx.fullname" . }}-admission
+  {{- if .Values.controller.admissionWebhooks.annotations }}
+  annotations: {{ toYaml .Values.controller.admissionWebhooks.annotations | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -34,6 +34,9 @@
                 "admissionWebhooks": {
                     "type": "object",
                     "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
                         "enabled": {
                             "type": "boolean"
                         },

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -373,6 +373,9 @@ controller:
   # Admission webhook support for Ingress resources can be enabled to prevent incorrectly formatted
   # rules from making their way into NGINX and potentially preventing the container from starting.
   admissionWebhooks:
+    annotations: {}
+    # ignore-check.kube-linter.io/no-read-only-rootfs: "This deployment needs write access to root filesystem".
+
     enabled: true
     timeoutSeconds: 10
     failurePolicy: Fail


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version |  |  |  |
| Existing Ingress resources are reconciled correctly |  |  |  |
| Fresh install |  |  |  |
| Fresh Ingress resources are reconciled correctly |  |  |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
