### PR TITLE
Templates: Add `controller.admissionWebhooks.existingPsp`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Templates: Add `controller.admissionWebhooks.patch.labels`. ([#360](https://github.com/giantswarm/nginx-ingress-controller-app/pull/360))
 - Templates: Add `controller.admissionWebhooks.annotations`. ([#362](https://github.com/giantswarm/nginx-ingress-controller-app/pull/362))
+- Templates: Add `controller.admissionWebhooks.existingPsp`. ([#365](https://github.com/giantswarm/nginx-ingress-controller-app/pull/365))
 
 ### Changed
 

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/clusterrole.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/clusterrole.yaml
@@ -25,6 +25,10 @@ rules:
     resources: ['podsecuritypolicies']
     verbs:     ['use']
     resourceNames:
+    {{- with .Values.controller.admissionWebhooks.existingPsp }}
+    - {{ . }}
+    {{- else }}
     - {{ include "ingress-nginx.fullname" . }}-admission
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/psp.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/psp.yaml
@@ -1,5 +1,5 @@
 {{- if (semverCompare "<1.25.0-0" .Capabilities.KubeVersion.Version) }}
-{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled .Values.podSecurityPolicy.enabled -}}
+{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled .Values.podSecurityPolicy.enabled (empty .Values.controller.admissionWebhooks.existingPsp) -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -40,6 +40,9 @@
                         "enabled": {
                             "type": "boolean"
                         },
+                        "existingPsp": {
+                            "type": "string"
+                        },
                         "failurePolicy": {
                             "type": "string",
                             "enum": ["Ignore", "Fail"]

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -381,6 +381,9 @@ controller:
     failurePolicy: Fail
     port: 8443
 
+    # -- Use an existing PSP instead of creating one
+    existingPsp: ""
+
     service:
       annotations: {}
 


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS |
| --- | --- |
| Upgrade from previous version | ✅ |
| Existing Ingress resources are reconciled correctly | ✅ |
| Fresh install | ✅ |
| Fresh Ingress resources are reconciled correctly | ✅ |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
