### PR TITLE
Revert 'Add support to create internal Load Balancers on GCP.'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Removed
+
+- Revert 'Add support to create internal Load Balancers on GCP.'. ([#367](https://github.com/giantswarm/nginx-ingress-controller-app/pull/367))
+
 ### Added
 
 - Templates: Add `controller.admissionWebhooks.patch.labels`. ([#360](https://github.com/giantswarm/nginx-ingress-controller-app/pull/360))

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -24,8 +24,6 @@ metadata:
     # this annotation adds lb rules for both TCP and UDP to allow UDP outbound connection with Standard LB
     service.beta.kubernetes.io/azure-load-balancer-mixed-protocols: "true"
     service.beta.kubernetes.io/azure-load-balancer-internal: "true"
-  {{- else if eq .Values.provider "gcp" }}
-    cloud.google.com/load-balancer-type: "Internal"
   {{- end }}
   {{- end }}
   name: {{ include "resource.controller-service-internal.name" . }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -28,10 +28,6 @@ metadata:
     {{- if not .Values.controller.service.public }}
     service.beta.kubernetes.io/azure-load-balancer-internal: "true"
     {{- end }}
-  {{- else if eq .Values.provider "gcp" }}
-    {{- if not .Values.controller.service.public }}
-    cloud.google.com/load-balancer-type: "Internal"
-    {{- end }}
   {{- end }}
   {{- end }}
   name: {{ include "resource.controller-service.name" . }}

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -291,12 +291,12 @@ controller:
     externalTrafficPolicy: "Local"
 
     # controller.service.public
-    # Applies to clusters running on AWS or Azure or GCP.
+    # Applies to clusters running on AWS or Azure.
     # Valid values: true for public, false for internal
     public: true
 
     # controller.service.subdomain
-    # Applies to clusters running on AWS or Azure or GCP.
+    # Applies to clusters running on AWS or Azure.
     # Configures external dns subdomain to be appeneded to base domain in definition of cloud load balancer's fully qualified hostname.
     subdomain: "ingress"
 
@@ -347,7 +347,7 @@ controller:
       externalTrafficPolicy: "Local"
 
       # controller.service.internal.subdomain
-      # Applies to clusters running on AWS or Azure or GCP.
+      # Applies to clusters running on AWS or Azure.
       # Configures external dns subdomain to be appeneded to base domain in definition of cloud load balancer's fully qualified hostname.
       subdomain: "ingress-internal"
 
@@ -527,7 +527,7 @@ podSecurityPolicy:
 # This value is set automatically. Do not overwrite this value.
 baseDomain:
 
-# provider (aws|kvm|azure|gcp)
+# provider (aws|kvm|azure)
 # The provider that the cluster is running on.
 # This value is set automatically, Do not overwrite this value.
 provider: aws


### PR DESCRIPTION
Didn't work anyway and provider-specific business logic will be deprecated in the future due to upstream alignment.