### PR TITLE
Helpers: Rename `labels.selector` to `ingress-nginx.selectorLabels`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - HPA: Disable when KEDA is enabled.
 - Admission Webhooks: Align from upstream. ([#370](https://github.com/giantswarm/nginx-ingress-controller-app/pull/370))
 - Ingress Class: Align from upstream. ([#371](https://github.com/giantswarm/nginx-ingress-controller-app/pull/371))
+- Helpers: Rename `labels.selector` to `ingress-nginx.selectorLabels`. ([#372](https://github.com/giantswarm/nginx-ingress-controller-app/pull/372))
 
 ## [2.20.0] - 2022-11-02
 

--- a/helm/nginx-ingress-controller-app/templates/_helpers.tpl
+++ b/helm/nginx-ingress-controller-app/templates/_helpers.tpl
@@ -18,7 +18,7 @@ Common labels
 */}}
 {{- define "ingress-nginx.labels" -}}
 app: {{ include "name" . | quote }}
-{{ include "labels.selector" . }}
+{{ include "ingress-nginx.selectorLabels" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/name: {{ include "name" . | quote }}
 app.kubernetes.io/instance: {{ .Release.Name | quote }}
@@ -32,7 +32,7 @@ helm.sh/chart: {{ include "chart" . | quote }}
 {{/*
 Selector labels
 */}}
-{{- define "labels.selector" -}}
+{{- define "ingress-nginx.selectorLabels" -}}
 k8s-app: {{ .Release.Name | quote }}
 {{- end -}}
 

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -19,7 +19,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "labels.selector" . | nindent 6 }}
+      {{- include "ingress-nginx.selectorLabels" . | nindent 6 }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/helm/nginx-ingress-controller-app/templates/controller-metrics-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-metrics-service.yaml
@@ -23,4 +23,4 @@ spec:
     protocol: TCP
     targetPort: metrics
   selector:
-    {{- include "labels.selector" . | nindent 4 }}
+    {{- include "ingress-nginx.selectorLabels" . | nindent 4 }}

--- a/helm/nginx-ingress-controller-app/templates/controller-poddisruptionbudget.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-poddisruptionbudget.yaml
@@ -8,6 +8,6 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "labels.selector" . | nindent 6 }}
+      {{- include "ingress-nginx.selectorLabels" . | nindent 6 }}
   maxUnavailable: {{ .Values.controller.maxUnavailable }}
 {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -55,7 +55,7 @@ spec:
     nodePort: {{ .Values.controller.service.internal.nodePorts.https }}
     {{- end }}
   selector:
-    {{- include "labels.selector" . | nindent 4 }}
+    {{- include "ingress-nginx.selectorLabels" . | nindent 4 }}
   {{- if .Values.controller.service.internal.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.controller.service.internal.externalTrafficPolicy }}
   {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service-webhook.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-webhook.yaml
@@ -16,5 +16,5 @@ spec:
       port: 443
       targetPort: webhook
   selector:
-    {{- include "labels.selector" . | nindent 4 }}
+    {{- include "ingress-nginx.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -59,7 +59,7 @@ spec:
     nodePort: {{ .Values.controller.service.nodePorts.https }}
     {{- end }}
   selector:
-    {{- include "labels.selector" . | nindent 4 }}
+    {{- include "ingress-nginx.selectorLabels" . | nindent 4 }}
   {{- if .Values.controller.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.controller.service.externalTrafficPolicy }}
   {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/np.yaml
+++ b/helm/nginx-ingress-controller-app/templates/np.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      {{- include "labels.selector" . | nindent 6 }}
+      {{- include "ingress-nginx.selectorLabels" . | nindent 6 }}
   ingress:
   - ports:
     {{- range $key, $value := .Values.controller.containerPort }}


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version |  |  |  |
| Existing Ingress resources are reconciled correctly |  |  |  |
| Fresh install |  |  |  |
| Fresh Ingress resources are reconciled correctly |  |  |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
