### PR TITLE
PDB: Align from upstream & add `minAvailable`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - HPA: Add `controller.autoscalingTemplate`.
   - HPA: Add `controller.autoscaling.behavior`.
   - HPA: Add all KEDA values.
+- PDB: Add `minAvailable`. ([#373](https://github.com/giantswarm/nginx-ingress-controller-app/pull/373))
 
 ### Changed
 
@@ -28,6 +29,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Admission Webhooks: Align from upstream. ([#370](https://github.com/giantswarm/nginx-ingress-controller-app/pull/370))
 - Ingress Class: Align from upstream. ([#371](https://github.com/giantswarm/nginx-ingress-controller-app/pull/371))
 - Helpers: Rename `labels.selector` to `ingress-nginx.selectorLabels`. ([#372](https://github.com/giantswarm/nginx-ingress-controller-app/pull/372))
+- PDB: Align from upstream. ([#373](https://github.com/giantswarm/nginx-ingress-controller-app/pull/373))
 
 ## [2.20.0] - 2022-11-02
 

--- a/helm/nginx-ingress-controller-app/templates/controller-poddisruptionbudget.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-poddisruptionbudget.yaml
@@ -1,13 +1,23 @@
-{{- if or (and .Values.controller.autoscaling.enabled (gt (.Values.controller.autoscaling.minReplicas | int) 1)) (gt (.Values.controller.replicaCount | int) 1) }}
-apiVersion: policy/v1beta1
+{{- if or (and .Values.controller.autoscaling.enabled (gt (.Values.controller.autoscaling.minReplicas | int) 1)) (and (not .Values.controller.autoscaling.enabled) (gt (.Values.controller.replicaCount | int) 1)) }}
+apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "ingress-nginx.fullname" . }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+    {{- with .Values.controller.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "ingress-nginx.controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:
       {{- include "ingress-nginx.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: controller
+  {{- if .Values.controller.minAvailable }}
+  minAvailable: {{ .Values.controller.minAvailable }}
+  {{- else if .Values.controller.maxUnavailable }}
   maxUnavailable: {{ .Values.controller.maxUnavailable }}
+  {{- end }}
 {{- end }}

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -425,6 +425,9 @@
                         }
                     }
                 },
+                "minAvailable": {
+                    "type": "integer"
+                },
                 "minReadySeconds": {
                     "type": "integer"
                 },

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -100,9 +100,9 @@ controller:
   # the desired number of Pods.
   maxSurge: 1
 
-  # controller.maxUnavailable
-  # Configures maximum number of unavailable replicas while doing a
-  # rolling upgrade.
+  # -- Define either 'minAvailable' or 'maxUnavailable', never both.
+  # minAvailable: 1
+  # -- Define either 'minAvailable' or 'maxUnavailable', never both.
   maxUnavailable: 1
 
   # -- Use a `DaemonSet` or `Deployment`


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version | ✅ |  |  |
| Existing Ingress resources are reconciled correctly | ✅ |  |  |
| Fresh install | ✅ |  |  |
| Fresh Ingress resources are reconciled correctly | ✅ |  |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
