### PR TITLE
Ingress Class: Align to upstream.

### DIFF
--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -292,20 +292,6 @@
                         },
                         "name": {
                             "type": "string"
-                        },
-                        "parameters": {
-                            "type": "object",
-                            "properties": {
-                                "apiGroup": {
-                                    "type": "string"
-                                },
-                                "kind": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            }
                         }
                     }
                 },

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -307,18 +307,17 @@ controller:
   # Process IngressClass per name (additionally as per spec.controller).
   ingressClassByName: false
 
-  # controller.ingressClassResource
-  # This section refers to the creation of the IngressClass resource
-  # IngressClass resources are supported since k8s >= 1.18 and required since k8s >= 1.19
+  ## This section refers to the creation of the IngressClass resource
+  ## IngressClass resources are supported since k8s >= 1.18 and required since k8s >= 1.19
   ingressClassResource:
+    # -- Name of the ingressClass
     name: nginx
+    # -- Is this ingressClass enabled or not
     enabled: true
+    # -- Is this the default ingressClass for the cluster
     default: false
+    # -- Controller-value of the controller that is processing this ingressClass
     controllerValue: "k8s.io/ingress-nginx"
-    # parameters:
-    #   apiGroup: ""
-    #   kind: ""
-    #   name: ""
 
   # controller.userID
   # The userID that the container will run as. 101 is the www-data user.


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version |  |  |  |
| Existing Ingress resources are reconciled correctly |  |  |  |
| Fresh install |  |  |  |
| Fresh Ingress resources are reconciled correctly |  |  |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
