### PR TITLE
Webhook: Use `cert-manager` for certificate lifecycle management.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-- Service: Add CAPA support.
+### Added
+
+- Service: Add CAPA support. ([#380](https://github.com/giantswarm/nginx-ingress-controller-app/pull/380))
+- Webhook: Use `cert-manager` for certificate lifecycle management. ([#386](https://github.com/giantswarm/nginx-ingress-controller-app/pull/386))
 
 ## [2.21.0] - 2023-01-02
 

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/cert-manager.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/cert-manager.yaml
@@ -1,0 +1,63 @@
+{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.certManager.enabled -}}
+{{- if not .Values.controller.admissionWebhooks.certManager.issuerRef -}}
+# Create a selfsigned Issuer, in order to create a root CA certificate for
+# signing webhook serving certificates
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "ingress-nginx.fullname" . }}-self-signed-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+---
+# Generate a CA Certificate used to sign certificates for the webhook
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "ingress-nginx.fullname" . }}-root-cert
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: {{ include "ingress-nginx.fullname" . }}-root-cert
+  duration: {{ .Values.controller.admissionWebhooks.certManager.rootCert.duration | default "43800h0m0s" | quote }}
+  issuerRef:
+    name: {{ include "ingress-nginx.fullname" . }}-self-signed-issuer
+  commonName: "ca.webhook.ingress-nginx"
+  isCA: true
+  subject:
+    organizations:
+      - ingress-nginx
+---
+# Create an Issuer that uses the above generated CA certificate to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "ingress-nginx.fullname" . }}-root-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  ca:
+    secretName: {{ include "ingress-nginx.fullname" . }}-root-cert
+{{- end }}
+---
+# generate a server certificate for the apiservices to use
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "ingress-nginx.fullname" . }}-admission
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: {{ include "ingress-nginx.fullname" . }}-admission
+  duration: {{ .Values.controller.admissionWebhooks.certManager.admissionCert.duration | default "8760h0m0s" | quote }}
+  issuerRef:
+    {{- if .Values.controller.admissionWebhooks.certManager.issuerRef }}
+    {{- toYaml .Values.controller.admissionWebhooks.certManager.issuerRef | nindent 4 }}
+    {{- else }}
+    name: {{ include "ingress-nginx.fullname" . }}-root-issuer
+    {{- end }}
+  dnsNames:
+    - {{ include "ingress-nginx.controller.fullname" . }}-admission
+    - {{ include "ingress-nginx.controller.fullname" . }}-admission.{{ .Release.Namespace }}
+    - {{ include "ingress-nginx.controller.fullname" . }}-admission.{{ .Release.Namespace }}.svc
+  subject:
+    organizations:
+      - ingress-nginx-admission
+{{- end -}}

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/clusterrole.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled -}}
+{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled (not .Values.controller.admissionWebhooks.certManager.enabled) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled -}}
+{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled (not .Values.controller.admissionWebhooks.certManager.enabled) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled -}}
+{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled (not .Values.controller.admissionWebhooks.certManager.enabled) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled -}}
+{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled (not .Values.controller.admissionWebhooks.certManager.enabled) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/role.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled -}}
+{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled (not .Values.controller.admissionWebhooks.certManager.enabled) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/rolebinding.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled -}}
+{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled (not .Values.controller.admissionWebhooks.certManager.enabled) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/serviceaccount.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/job-patch/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled -}}
+{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled (not .Values.controller.admissionWebhooks.certManager.enabled) -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/nginx-ingress-controller-app/templates/admission-webhooks/validating-webhook.yaml
+++ b/helm/nginx-ingress-controller-app/templates/admission-webhooks/validating-webhook.yaml
@@ -4,8 +4,13 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
+  annotations:
+  {{- if .Values.controller.admissionWebhooks.certManager.enabled }}
+    certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s-admission" .Release.Namespace (include "ingress-nginx.fullname" .) | quote }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s-admission" .Release.Namespace (include "ingress-nginx.fullname" .) | quote }}
+  {{- end }}
   {{- if .Values.controller.admissionWebhooks.annotations }}
-  annotations: {{ toYaml .Values.controller.admissionWebhooks.annotations | nindent 4 }}
+    {{- toYaml .Values.controller.admissionWebhooks.annotations | nindent 4 }}
   {{- end }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -37,6 +37,41 @@
                         "annotations": {
                             "type": "object"
                         },
+                        "certManager": {
+                            "type": "object",
+                            "properties": {
+                                "admissionCert": {
+                                    "type": "object",
+                                    "properties": {
+                                        "duration": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "issuerRef": {
+                                    "type": "object",
+                                    "properties": {
+                                        "kind": {
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "rootCert": {
+                                    "type": "object",
+                                    "properties": {
+                                        "duration": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
                         "certificate": {
                             "type": "string"
                         },

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -571,6 +571,18 @@ controller:
         runAsUser: 2000
         fsGroup: 2000
 
+    # Use certmanager to generate webhook certs
+    certManager:
+      enabled: false
+      # self-signed root certificate
+      rootCert:
+        duration: ""  # default to be 5y
+      admissionCert:
+        duration: ""  # default to be 1y
+      # issuerRef:
+      #   name: "issuer"
+      #   kind: "ClusterIssuer"
+
   # controller.updateIngressStatus
   # Enables updating of the loadbalancer status of Ingress objects which this controller is reconciling. Unless you are
   # managing DNS for ingresses via an external method, this should always be left enabled.


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version |  |  |  |
| Existing Ingress resources are reconciled correctly |  |  |  |
| Fresh install |  |  |  |
| Fresh Ingress resources are reconciled correctly |  |  |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
