### PR TITLE
HPA: Make `apiVersion` configurable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Service: Add CAPA support. ([#380](https://github.com/giantswarm/nginx-ingress-controller-app/pull/380))
 - Webhook: Use `cert-manager` for certificate lifecycle management. ([#386](https://github.com/giantswarm/nginx-ingress-controller-app/pull/386))
+- HPA: Make `apiVersion` configurable. ([#387](https://github.com/giantswarm/nginx-ingress-controller-app/pull/387))
 
 ## [2.21.0] - 2023-01-02
 

--- a/helm/nginx-ingress-controller-app/templates/controller-hpa.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-hpa.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.controller.autoscaling.enabled (or (eq .Values.controller.kind "Deployment") (eq .Values.controller.kind "Both")) -}}
 {{- if not .Values.controller.keda.enabled }}
 
-apiVersion: autoscaling/v2beta2
+apiVersion: {{ .Values.controller.autoscaling.apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   annotations:

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -242,6 +242,9 @@
                         "annotations": {
                             "type": "object"
                         },
+                        "apiVersion": {
+                            "type": "string"
+                        },
                         "behavior": {
                             "type": "object"
                         },

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -225,6 +225,7 @@ controller:
 
   # Mutually exclusive with keda autoscaling
   autoscaling:
+    apiVersion: autoscaling/v2
     enabled: true
     annotations: {}
     minReplicas: 2


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version | ✓ | ✓ |  |
| Existing Ingress resources are reconciled correctly | ✓ | ✓ |  |
| Fresh install | ✓ | ✓ |  |
| Fresh Ingress resources are reconciled correctly | ✓ | ✓ |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
