### PR TITLE
HPA: Remove `controller.autoscaling.apiVersion`, use capabilites instead.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Removed
+
+- HPA: Remove `controller.autoscaling.apiVersion`, use capabilites instead. ([#392](https://github.com/giantswarm/nginx-ingress-controller-app/pull/392))
+
 ## [2.22.0] - 2023-01-17
 
 ### Added

--- a/helm/nginx-ingress-controller-app/templates/controller-hpa.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-hpa.yaml
@@ -1,7 +1,5 @@
-{{- if and .Values.controller.autoscaling.enabled (or (eq .Values.controller.kind "Deployment") (eq .Values.controller.kind "Both")) -}}
-{{- if not .Values.controller.keda.enabled }}
-
-apiVersion: {{ .Values.controller.autoscaling.apiVersion }}
+{{- if and .Values.controller.autoscaling.enabled (or (eq .Values.controller.kind "Deployment") (eq .Values.controller.kind "Both")) (not .Values.controller.keda.enabled) -}}
+apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta2" (semverCompare ">=1.23.0-0" .Capabilities.KubeVersion.Version) }}
 kind: HorizontalPodAutoscaler
 metadata:
   annotations:
@@ -48,5 +46,3 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}
-{{- end }}
-

--- a/helm/nginx-ingress-controller-app/templates/controller-hpa.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.controller.autoscaling.enabled (or (eq .Values.controller.kind "Deployment") (eq .Values.controller.kind "Both")) (not .Values.controller.keda.enabled) -}}
-apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta2" (semverCompare ">=1.23.0-0" .Capabilities.KubeVersion.Version) }}
+apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta2" (.Capabilities.APIVersions.Has "autoscaling/v2") }}
 kind: HorizontalPodAutoscaler
 metadata:
   annotations:

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -242,9 +242,6 @@
                         "annotations": {
                             "type": "object"
                         },
-                        "apiVersion": {
-                            "type": "string"
-                        },
                         "behavior": {
                             "type": "object"
                         },

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -234,7 +234,6 @@ controller:
 
   # Mutually exclusive with keda autoscaling
   autoscaling:
-    apiVersion: autoscaling/v2
     enabled: true
     annotations: {}
     minReplicas: 2


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version | ✔ |  |  |
| Existing Ingress resources are reconciled correctly | ✔ |  |  |
| Fresh install | ✔ |  |  |
| Fresh Ingress resources are reconciled correctly | ✔ |  |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
