### PR TITLE
Metrics: Add `app.kubernetes.io/component` to selector.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Metrics: Add `app.kubernetes.io/component` to selector. ([#393](https://github.com/giantswarm/nginx-ingress-controller-app/pull/393))
+
 ## [2.22.0] - 2023-01-17
 
 ### Added

--- a/helm/nginx-ingress-controller-app/templates/controller-service-metrics.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-metrics.yaml
@@ -48,4 +48,5 @@ spec:
     {{- end }}
   selector:
     {{- include "ingress-nginx.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
 {{- end }}


### PR DESCRIPTION
This is already done in the `controller-service-webhook.yaml` and the deployment pods have the required label.

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version | ✔ |  |  |
| Existing Ingress resources are reconciled correctly | ✔ |  |  |
| Fresh install | ✔ |  |  |
| Fresh Ingress resources are reconciled correctly | ✔ |  |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
