### PR TITLE
Use `context: architect` for all jobs in circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ workflows:
 
       # deploy to openstack installations (only tags)
       - architect/push-to-app-collection:
+          context: architect
           name: push-to-openstack-app-collection
           app_name: "nginx-ingress-controller-app"
           app_namespace: "kube-system"


### PR DESCRIPTION
This PR adds `context: architect` to the `push-to-app-collection` job for openstack