### PR TITLE
Move from `maxUnavailable: 1` to `maxUnavailable: 25%`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Change `PodDisruptionBudget` to move from `maxUnavailable: 1` to `maxUnavailable: 25%` for better scaling
 
-
 ## [2.23.1] - 2023-02-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Change `PodDisruptionBudget` to move from `maxUnavailable: 1` to `maxUnavailable: 25%` for better scaling
+
+
 ## [2.23.1] - 2023-02-10
 
 ### Fixed

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -468,7 +468,7 @@
                     "type": "integer"
                 },
                 "maxUnavailable": {
-                    "type": "integer"
+                    "type": ["integer", "string"]
                 },
                 "metrics": {
                     "type": "object",

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -103,7 +103,7 @@ controller:
   # -- Define either 'minAvailable' or 'maxUnavailable', never both.
   # minAvailable: 1
   # -- Define either 'minAvailable' or 'maxUnavailable', never both.
-  maxUnavailable: 1
+  maxUnavailable: "25%"
 
   # -- Use a `DaemonSet` or `Deployment`
   kind: Deployment


### PR DESCRIPTION
Move from maxUnavailable: 1 to maxUnavailable: 25% in the Pod Disruption Budget so that the maximum number of unavailable pods scales at the same pace as the cluster does.

