### PR TITLE
Default Backend: Add `defaultBackend.updateStrategy` & `defaultBackend.minReadySeconds`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Default Backend: Add `defaultBackend.updateStrategy` & `defaultBackend.minReadySeconds`. ([#406](https://github.com/giantswarm/nginx-ingress-controller-app/pull/406))
+
 ## [2.24.0] - 2023-02-14
 
 ### Changed

--- a/helm/nginx-ingress-controller-app/templates/default-backend-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/default-backend-deployment.yaml
@@ -19,6 +19,11 @@ spec:
   replicas: {{ .Values.defaultBackend.replicaCount }}
 {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- if .Values.defaultBackend.updateStrategy }}
+  strategy:
+    {{ toYaml .Values.defaultBackend.updateStrategy | nindent 4 }}
+  {{- end }}
+  minReadySeconds: {{ .Values.defaultBackend.minReadySeconds }}
   template:
     metadata:
     {{- if .Values.defaultBackend.podAnnotations }}

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -861,6 +861,9 @@
                 "minAvailable": {
                     "type": "integer"
                 },
+                "minReadySeconds": {
+                    "type": "integer"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -949,6 +952,22 @@
                 },
                 "tolerations": {
                     "type": "array"
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "rollingUpdate": {
+                            "type": "object",
+                            "properties": {
+                                "maxUnavailable": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         },

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -703,6 +703,17 @@ defaultBackend:
     successThreshold: 1
     timeoutSeconds: 5
 
+  # -- The update strategy to apply to the Deployment or DaemonSet
+  ##
+  updateStrategy: {}
+  #  rollingUpdate:
+  #    maxUnavailable: 1
+  #  type: RollingUpdate
+
+  # -- `minReadySeconds` to avoid killing pods before we are ready
+  ##
+  minReadySeconds: 0
+
   # -- Node tolerations for server scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version | ✓ | ✓ |  |
| Existing Ingress resources are reconciled correctly | ✓ | ✓ |  |
| Fresh install | ✓ | ✓ |  |
| Fresh Ingress resources are reconciled correctly | ✓ | ✓ |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
