### PR TITLE
update sha webhook certgen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - ConfigMap: Align metadata.
   - ConfigMap: Rename `configmap.yaml` -> `controller-configmap.yaml`.
   - ConfigMap: Align indention.
+- AdmissionWebhooks: Update digest to match last SHA.
 
 ## [2.24.0] - 2023-02-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - ConfigMap: Align metadata.
   - ConfigMap: Rename `configmap.yaml` -> `controller-configmap.yaml`.
   - ConfigMap: Align indention.
+
+## [2.24.1] - 2023-03-02
+
+### Changed
+
 - Webhook: Update digest to match last SHA. ([#416](https://github.com/giantswarm/nginx-ingress-controller-app/pull/416))
 
 ## [2.24.0] - 2023-02-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - ConfigMap: Align metadata.
   - ConfigMap: Rename `configmap.yaml` -> `controller-configmap.yaml`.
   - ConfigMap: Align indention.
-- AdmissionWebhooks: Update digest to match last SHA.
+- AdmissionWebhooks: Update digest to match last SHA ([#416](https://github.com/giantswarm/nginx-ingress-controller-app/pull/416)).
 
 ## [2.24.0] - 2023-02-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - ConfigMap: Align metadata.
   - ConfigMap: Rename `configmap.yaml` -> `controller-configmap.yaml`.
   - ConfigMap: Align indention.
-- AdmissionWebhooks: Update digest to match last SHA ([#416](https://github.com/giantswarm/nginx-ingress-controller-app/pull/416)).
+- Webhook: Update digest to match last SHA. ([#416](https://github.com/giantswarm/nginx-ingress-controller-app/pull/416))
 
 ## [2.24.0] - 2023-02-14
 

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -644,7 +644,7 @@ controller:
         ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
         ## repository:
         tag: v20220916-gd32f8c343
-        digest: sha256:c0e3bef270e179a5e4ab373f8ba6d57f596f3683d9d40c33ea900b19ec182ba2
+        digest: sha256:39c5b2e3310dc4264d638ad28d9d1d96c4cbb2b2dcfb52368fe4e3c63f61e10f
         pullPolicy: IfNotPresent
       # -- Provide a priority class name to the webhook patching job
       ##


### PR DESCRIPTION
- Update digest of giantswarm/ingress-nginx-kube-webhook-certgen image
- Update changelog

<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version |  |  |  |
| Existing Ingress resources are reconciled correctly |  |  |  |
| Fresh install |  |  |  |
| Fresh Ingress resources are reconciled correctly |  |  |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
