### PR TITLE
Merge v2.24.1 into `main`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Webhook: Update digest to match last SHA. ([#421](https://github.com/giantswarm/nginx-ingress-controller-app/pull/421))
+
 ## [2.24.0] - 2023-02-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+## [2.24.1] - 2023-03-02
+
 ### Changed
 
 - Webhook: Update digest to match last SHA. ([#421](https://github.com/giantswarm/nginx-ingress-controller-app/pull/421))
@@ -808,7 +810,8 @@ In recent platform releases (Azure v12.0.2, and AWS v12.1.4 and v11.5.4) we've i
 
 Previous versions changelog can be found [here](https://github.com/giantswarm/kubernetes-nginx-ingress-controller/blob/master/CHANGELOG.md)
 
-[Unreleased]: https://github.com/giantswarm/nginx-ingress-controller-app/compare/v2.24.0...HEAD
+[Unreleased]: https://github.com/giantswarm/nginx-ingress-controller-app/compare/v2.24.1...HEAD
+[2.24.1]: https://github.com/giantswarm/nginx-ingress-controller-app/compare/v2.24.0...v2.24.1
 [2.24.0]: https://github.com/giantswarm/nginx-ingress-controller-app/compare/v2.23.1...v2.24.0
 [2.23.1]: https://github.com/giantswarm/nginx-ingress-controller-app/compare/v2.23.0...v2.23.1
 [2.23.0]: https://github.com/giantswarm/nginx-ingress-controller-app/compare/v2.22.1...v2.23.0

--- a/helm/nginx-ingress-controller-app/Chart.yaml
+++ b/helm/nginx-ingress-controller-app/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/giantswarm/nginx-ingress-controller-app
 icon: https://s.giantswarm.io/app-icons/nginx-ingress-controller/2/icon_dark.svg
 kubeVersion: ">=1.20.0-0"
 name: nginx-ingress-controller-app
-version: 2.24.0
+version: 2.24.1
 sources:
   - https://github.com/kubernetes/ingress-nginx/
 annotations:

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -564,7 +564,7 @@ controller:
         ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
         ## repository:
         tag: v20220916-gd32f8c343
-        digest: sha256:c0e3bef270e179a5e4ab373f8ba6d57f596f3683d9d40c33ea900b19ec182ba2
+        digest: sha256:39c5b2e3310dc4264d638ad28d9d1d96c4cbb2b2dcfb52368fe4e3c63f61e10f
         pullPolicy: IfNotPresent
       # -- Provide a priority class name to the webhook patching job
       ##


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version |  |  |  |
| Existing Ingress resources are reconciled correctly |  |  |  |
| Fresh install |  |  |  |
| Fresh Ingress resources are reconciled correctly |  |  |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
