### PR TITLE
Service: Align to upstream.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Internal Service: Align `controller.service.internal.loadBalancerSourceRanges`.
   - Internal Service: Reorder `controller.service.internal.externalTrafficPolicy`.
   - Internal Service: Align indention of `ports`.
+  - Internal Service: Align node port checks.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Service: Implement `controller.service.clusterIP`.\
     **NOTE:** The cluster IP of existing services can not be changed. The app deployment might fail when defining this for already installed app instances.
   - Service: Implement `controller.service.externalIPs`.
+  - Service: Implement `controller.service.loadBalancerIP`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Service: Implement `controller.service.enableHttp`.
   - Service: Implement `controller.service.enableHttps`.
   - Service: Implement `controller.service.appProtocol`.
+  - Service: Implement `controller.service.external.enabled`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Service: Align to upstream. ([#425](https://github.com/giantswarm/nginx-ingress-controller-app/pull/425))
+  - Service: Implement `controller.service.clusterIP`.\
+    **NOTE:** The cluster IP of existing services can not be changed. The app deployment might fail when defining this for already installed app instances.
+
 ### Changed
 
 - Service: Align to upstream. ([#425](https://github.com/giantswarm/nginx-ingress-controller-app/pull/425))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Service: Implement node ports for `tcp` and `udp`.
   - Internal Service: Implement `controller.service.internal.loadBalancerIP`.
   - Internal Service: Implement `controller.service.enableHttp` & `controller.service.enableHttps`.
+  - Internal Service: Implement `controller.service.appProtocol`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Service: Reorder name & namespace.
   - Service: Align `controller.service.loadBalancerSourceRanges`.
   - Service: Align `controller.service.externalTrafficPolicy`.
+  - Service: Align indention of `ports`.
 
 ## [2.25.1] - 2023-03-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Service: Implement `controller.service.enableHttps`.
   - Service: Implement `controller.service.appProtocol`.
   - Service: Implement `controller.service.external.enabled`.
+  - Service: Add `portNamePrefix`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Service: Align to upstream. ([#425](https://github.com/giantswarm/nginx-ingress-controller-app/pull/425))
+  - Service: Reorder name & namespace.
+
 ## [2.25.1] - 2023-03-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Service: Implement `controller.service.externalIPs`.
   - Service: Implement `controller.service.loadBalancerIP`.
   - Service: Implement `controller.service.sessionAffinity`.
+  - Service: Implement `controller.service.healthCheckNodePort`.\
+    **NOTE:** The health check node port of existing services can not be changed. The app deployment might fail when defining this for already installed app instances.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Internal Service: Align initial check.
   - Internal Service: Reorder name & namespace.
 
+### Removed
+
+- Service: Align to upstream. ([#425](https://github.com/giantswarm/nginx-ingress-controller-app/pull/425))
+  - Internal Service: Remove `controller.service.internal.labels`.\
+    **NOTE:** This is part of our alignment to upstream. Use `controller.service.labels` instead.
+
 ## [2.25.1] - 2023-03-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Service: Align node port checks.
   - Internal Service: Align initial check.
   - Internal Service: Reorder name & namespace.
+  - Internal Service: Align `controller.service.internal.loadBalancerSourceRanges`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Service: Implement `controller.service.healthCheckNodePort`.\
     **NOTE:** The health check node port of existing services can not be changed. The app deployment might fail when defining this for already installed app instances.
   - Service: Implement `controller.service.ipFamilyPolicy`.
+  - Service: Implement `controller.service.ipFamilies`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Service: Add `portNamePrefix`.
   - Service: Add `controller.service.nodePorts.tcp` & `controller.service.nodePorts.udp`.
   - Service: Implement node ports for `tcp` and `udp`.
+  - Internal Service: Implement `controller.service.internal.loadBalancerIP`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Service: Implement `controller.service.external.enabled`.
   - Service: Add `portNamePrefix`.
   - Service: Add `controller.service.nodePorts.tcp` & `controller.service.nodePorts.udp`.
+  - Service: Implement node ports for `tcp` and `udp`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Service: Align indention of `ports`.
   - Service: Align node port checks.
   - Internal Service: Align initial check.
+  - Internal Service: Reorder name & namespace.
 
 ## [2.25.1] - 2023-03-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
     **NOTE:** The cluster IP of existing services can not be changed. The app deployment might fail when defining this for already installed app instances.
   - Service: Implement `controller.service.externalIPs`.
   - Service: Implement `controller.service.loadBalancerIP`.
+  - Service: Implement `controller.service.sessionAffinity`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
     **NOTE:** The health check node port of existing services can not be changed. The app deployment might fail when defining this for already installed app instances.
   - Service: Implement `controller.service.ipFamilyPolicy`.
   - Service: Implement `controller.service.ipFamilies`.
+  - Service: Implement `controller.service.enableHttp`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Internal Service: Implement `controller.service.internal.loadBalancerIP`.
   - Internal Service: Implement `controller.service.enableHttp` & `controller.service.enableHttps`.
   - Internal Service: Implement `controller.service.appProtocol`.
+  - Internal Service: Add `controller.service.internal.nodePorts.tcp` & `controller.service.internal.nodePorts.udp`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Service: Align to upstream. ([#425](https://github.com/giantswarm/nginx-ingress-controller-app/pull/425))
   - Service: Implement `controller.service.clusterIP`.\
     **NOTE:** The cluster IP of existing services can not be changed. The app deployment might fail when defining this for already installed app instances.
+  - Service: Implement `controller.service.externalIPs`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Internal Service: Reorder `controller.service.internal.externalTrafficPolicy`.
   - Internal Service: Align indention of `ports`.
   - Internal Service: Align node port checks.
+  - Values: Align to upstream.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Service: Add `controller.service.nodePorts.tcp` & `controller.service.nodePorts.udp`.
   - Service: Implement node ports for `tcp` and `udp`.
   - Internal Service: Implement `controller.service.internal.loadBalancerIP`.
+  - Internal Service: Implement `controller.service.enableHttp` & `controller.service.enableHttps`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
     **NOTE:** This is part of our alignment to upstream. Use `controller.service.type` instead.
   - Internal Service: Remove `controller.service.internal.ports.http`.\
     **NOTE:** This is part of our alignment to upstream. Use `controller.service.ports.http` instead.
+  - Internal Service: Remove `controller.service.internal.ports.https`.\
+    **NOTE:** This is part of our alignment to upstream. Use `controller.service.ports.https` instead.
 
 ## [2.25.1] - 2023-03-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Internal Service: Reorder name & namespace.
   - Internal Service: Align `controller.service.internal.loadBalancerSourceRanges`.
   - Internal Service: Reorder `controller.service.internal.externalTrafficPolicy`.
+  - Internal Service: Align indention of `ports`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Service: Align to upstream. ([#425](https://github.com/giantswarm/nginx-ingress-controller-app/pull/425))
   - Service: Reorder name & namespace.
   - Service: Align `controller.service.loadBalancerSourceRanges`.
+  - Service: Align `controller.service.externalTrafficPolicy`.
 
 ## [2.25.1] - 2023-03-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
     **NOTE:** This is part of our alignment to upstream. Use `controller.service.labels` instead.
   - Internal Service: Remove `controller.service.internal.type`.\
     **NOTE:** This is part of our alignment to upstream. Use `controller.service.type` instead.
+  - Internal Service: Remove `controller.service.internal.ports.http`.\
+    **NOTE:** This is part of our alignment to upstream. Use `controller.service.ports.http` instead.
 
 ## [2.25.1] - 2023-03-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Service: Align `controller.service.loadBalancerSourceRanges`.
   - Service: Align `controller.service.externalTrafficPolicy`.
   - Service: Align indention of `ports`.
+  - Service: Align node port checks.
 
 ## [2.25.1] - 2023-03-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Internal Service: Align initial check.
   - Internal Service: Reorder name & namespace.
   - Internal Service: Align `controller.service.internal.loadBalancerSourceRanges`.
+  - Internal Service: Reorder `controller.service.internal.externalTrafficPolicy`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Service: Implement `controller.service.appProtocol`.
   - Service: Implement `controller.service.external.enabled`.
   - Service: Add `portNamePrefix`.
+  - Service: Add `controller.service.nodePorts.tcp` & `controller.service.nodePorts.udp`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Service: Align to upstream. ([#425](https://github.com/giantswarm/nginx-ingress-controller-app/pull/425))
   - Internal Service: Remove `controller.service.internal.labels`.\
     **NOTE:** This is part of our alignment to upstream. Use `controller.service.labels` instead.
+  - Internal Service: Remove `controller.service.internal.type`.\
+    **NOTE:** This is part of our alignment to upstream. Use `controller.service.type` instead.
 
 ## [2.25.1] - 2023-03-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Service: Implement `controller.service.sessionAffinity`.
   - Service: Implement `controller.service.healthCheckNodePort`.\
     **NOTE:** The health check node port of existing services can not be changed. The app deployment might fail when defining this for already installed app instances.
+  - Service: Implement `controller.service.ipFamilyPolicy`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Service: Align `controller.service.externalTrafficPolicy`.
   - Service: Align indention of `ports`.
   - Service: Align node port checks.
+  - Internal Service: Align initial check.
 
 ## [2.25.1] - 2023-03-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Internal Service: Implement `controller.service.enableHttp` & `controller.service.enableHttps`.
   - Internal Service: Implement `controller.service.appProtocol`.
   - Internal Service: Add `controller.service.internal.nodePorts.tcp` & `controller.service.internal.nodePorts.udp`.
+  - Internal Service: Implement node ports for `tcp` and `udp`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Service: Align to upstream. ([#425](https://github.com/giantswarm/nginx-ingress-controller-app/pull/425))
   - Service: Reorder name & namespace.
+  - Service: Align `controller.service.loadBalancerSourceRanges`.
 
 ## [2.25.1] - 2023-03-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Service: Implement `controller.service.ipFamilyPolicy`.
   - Service: Implement `controller.service.ipFamilies`.
   - Service: Implement `controller.service.enableHttp`.
+  - Service: Implement `controller.service.enableHttps`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Service: Implement `controller.service.ipFamilies`.
   - Service: Implement `controller.service.enableHttp`.
   - Service: Implement `controller.service.enableHttps`.
+  - Service: Implement `controller.service.appProtocol`.
 
 ### Changed
 

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -51,6 +51,9 @@ spec:
       port: {{ .Values.controller.service.ports.http }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.http }}
+    {{- if and (semverCompare ">=1.20" .Capabilities.KubeVersion.Version) (.Values.controller.service.appProtocol) }}
+      appProtocol: http
+    {{- end }}
     {{- if (and $setNodePorts (not (empty .Values.controller.service.internal.nodePorts.http))) }}
       nodePort: {{ .Values.controller.service.internal.nodePorts.http }}
     {{- end }}
@@ -60,6 +63,9 @@ spec:
       port: {{ .Values.controller.service.ports.https }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.https }}
+    {{- if and (semverCompare ">=1.20" .Capabilities.KubeVersion.Version) (.Values.controller.service.appProtocol) }}
+      appProtocol: https
+    {{- end }}
     {{- if (and $setNodePorts (not (empty .Values.controller.service.internal.nodePorts.https))) }}
       nodePort: {{ .Values.controller.service.internal.nodePorts.https }}
     {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -25,14 +25,14 @@ metadata:
     service.beta.kubernetes.io/azure-load-balancer-internal: "true"
   {{- end }}
   {{- end }}
-  name: {{ include "resource.controller-service-internal.name" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
   {{- if .Values.controller.service.internal.labels }}
     {{- toYaml .Values.controller.service.internal.labels | nindent 4 }}
   {{- end }}
+  name: {{ include "resource.controller-service-internal.name" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   type: {{ .Values.controller.service.internal.type }}
   {{- with .Values.controller.service.internal.loadBalancerSourceRanges }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -12,7 +12,7 @@ metadata:
     {{ .Values.controller.service.externalDNS.annotation }}
     {{- end }}
   {{- end }}
-  {{- if eq .Values.controller.service.internal.type "LoadBalancer" }}
+  {{- if eq .Values.controller.service.type "LoadBalancer" }}
   {{- if or (eq .Values.provider "aws") (eq .Values.provider "capa") }}
     service.beta.kubernetes.io/aws-load-balancer-internal: "true"
     service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
@@ -34,7 +34,7 @@ metadata:
   name: {{ include "resource.controller-service-internal.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  type: {{ .Values.controller.service.internal.type }}
+  type: {{ .Values.controller.service.type }}
   {{- with .Values.controller.service.internal.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{ toYaml . | nindent 2 }}
   {{- end }}
@@ -43,14 +43,14 @@ spec:
     port: {{ .Values.controller.service.internal.ports.http }}
     protocol: TCP
     targetPort: {{ .Values.controller.service.targetPorts.http }}
-    {{- if eq .Values.controller.service.internal.type "NodePort" }}
+    {{- if eq .Values.controller.service.type "NodePort" }}
     nodePort: {{ .Values.controller.service.internal.nodePorts.http }}
     {{- end }}
   - name: https
     port: {{ .Values.controller.service.internal.ports.https }}
     protocol: TCP
     targetPort: {{ .Values.controller.service.targetPorts.https }}
-    {{- if eq .Values.controller.service.internal.type "NodePort" }}
+    {{- if eq .Values.controller.service.type "NodePort" }}
     nodePort: {{ .Values.controller.service.internal.nodePorts.https }}
     {{- end }}
   selector:

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -41,6 +41,9 @@ spec:
 {{- if .Values.controller.service.internal.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{ toYaml .Values.controller.service.internal.loadBalancerSourceRanges | nindent 4 }}
 {{- end }}
+{{- if .Values.controller.service.internal.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.controller.service.internal.externalTrafficPolicy }}
+{{- end }}
   ports:
   - name: http
     port: {{ .Values.controller.service.internal.ports.http }}
@@ -59,7 +62,4 @@ spec:
   selector:
     {{- include "ingress-nginx.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: controller
-  {{- if .Values.controller.service.internal.externalTrafficPolicy }}
-  externalTrafficPolicy: {{ .Values.controller.service.internal.externalTrafficPolicy }}
-  {{- end }}
 {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -70,6 +70,28 @@ spec:
       nodePort: {{ .Values.controller.service.internal.nodePorts.https }}
     {{- end }}
   {{- end }}
+  {{- range $key, $value := .Values.tcp }}
+    - name: {{ if $.Values.portNamePrefix }}{{ $.Values.portNamePrefix }}-{{ end }}{{ $key }}-tcp
+      port: {{ $key }}
+      protocol: TCP
+      targetPort: {{ if $.Values.portNamePrefix }}{{ $.Values.portNamePrefix }}-{{ end }}{{ $key }}-tcp
+    {{- if $.Values.controller.service.internal.nodePorts.tcp }}
+    {{- if index $.Values.controller.service.internal.nodePorts.tcp $key }}
+      nodePort: {{ index $.Values.controller.service.internal.nodePorts.tcp $key }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- range $key, $value := .Values.udp }}
+    - name: {{ if $.Values.portNamePrefix }}{{ $.Values.portNamePrefix }}-{{ end }}{{ $key }}-udp
+      port: {{ $key }}
+      protocol: UDP
+      targetPort: {{ if $.Values.portNamePrefix }}{{ $.Values.portNamePrefix }}-{{ end }}{{ $key }}-udp
+    {{- if $.Values.controller.service.internal.nodePorts.udp }}
+    {{- if index $.Values.controller.service.internal.nodePorts.udp $key }}
+      nodePort: {{ index $.Values.controller.service.internal.nodePorts.udp $key }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
   selector:
     {{- include "ingress-nginx.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: controller

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -21,7 +21,6 @@ metadata:
     {{- end }}
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
   {{- else if eq .Values.provider "azure" }}
-    # this annotation adds lb rules for both TCP and UDP to allow UDP outbound connection with Standard LB
     service.beta.kubernetes.io/azure-load-balancer-mixed-protocols: "true"
     service.beta.kubernetes.io/azure-load-balancer-internal: "true"
   {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -53,7 +53,7 @@ spec:
       nodePort: {{ .Values.controller.service.internal.nodePorts.http }}
     {{- end }}
     - name: https
-      port: {{ .Values.controller.service.internal.ports.https }}
+      port: {{ .Values.controller.service.ports.https }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.https }}
     {{- if eq .Values.controller.service.type "NodePort" }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -45,6 +45,7 @@ spec:
   externalTrafficPolicy: {{ .Values.controller.service.internal.externalTrafficPolicy }}
 {{- end }}
   ports:
+  {{- if .Values.controller.service.enableHttp }}
     - name: http
       port: {{ .Values.controller.service.ports.http }}
       protocol: TCP
@@ -52,6 +53,8 @@ spec:
     {{- if eq .Values.controller.service.type "NodePort" }}
       nodePort: {{ .Values.controller.service.internal.nodePorts.http }}
     {{- end }}
+  {{- end }}
+  {{- if .Values.controller.service.enableHttps }}
     - name: https
       port: {{ .Values.controller.service.ports.https }}
       protocol: TCP
@@ -59,6 +62,7 @@ spec:
     {{- if eq .Values.controller.service.type "NodePort" }}
       nodePort: {{ .Values.controller.service.internal.nodePorts.https }}
     {{- end }}
+  {{- end }}
   selector:
     {{- include "ingress-nginx.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: controller

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -28,8 +28,8 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
-  {{- if .Values.controller.service.internal.labels }}
-    {{- toYaml .Values.controller.service.internal.labels | nindent 4 }}
+  {{- if .Values.controller.service.labels }}
+    {{- toYaml .Values.controller.service.labels | nindent 4 }}
   {{- end }}
   name: {{ include "resource.controller-service-internal.name" . }}
   namespace: {{ .Release.Namespace }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -46,7 +46,7 @@ spec:
 {{- end }}
   ports:
     - name: http
-      port: {{ .Values.controller.service.internal.ports.http }}
+      port: {{ .Values.controller.service.ports.http }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.http }}
     {{- if eq .Values.controller.service.type "NodePort" }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -35,6 +35,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   type: {{ .Values.controller.service.type }}
+{{- if .Values.controller.service.internal.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.controller.service.internal.loadBalancerIP }}
+{{- end }}
   {{- with .Values.controller.service.internal.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{ toYaml . | nindent 2 }}
   {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -45,19 +45,19 @@ spec:
   externalTrafficPolicy: {{ .Values.controller.service.internal.externalTrafficPolicy }}
 {{- end }}
   ports:
-  - name: http
-    port: {{ .Values.controller.service.internal.ports.http }}
-    protocol: TCP
-    targetPort: {{ .Values.controller.service.targetPorts.http }}
+    - name: http
+      port: {{ .Values.controller.service.internal.ports.http }}
+      protocol: TCP
+      targetPort: {{ .Values.controller.service.targetPorts.http }}
     {{- if eq .Values.controller.service.type "NodePort" }}
-    nodePort: {{ .Values.controller.service.internal.nodePorts.http }}
+      nodePort: {{ .Values.controller.service.internal.nodePorts.http }}
     {{- end }}
-  - name: https
-    port: {{ .Values.controller.service.internal.ports.https }}
-    protocol: TCP
-    targetPort: {{ .Values.controller.service.targetPorts.https }}
+    - name: https
+      port: {{ .Values.controller.service.internal.ports.https }}
+      protocol: TCP
+      targetPort: {{ .Values.controller.service.targetPorts.https }}
     {{- if eq .Values.controller.service.type "NodePort" }}
-    nodePort: {{ .Values.controller.service.internal.nodePorts.https }}
+      nodePort: {{ .Values.controller.service.internal.nodePorts.https }}
     {{- end }}
   selector:
     {{- include "ingress-nginx.selectorLabels" . | nindent 4 }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -38,9 +38,9 @@ spec:
 {{- if .Values.controller.service.internal.loadBalancerIP }}
   loadBalancerIP: {{ .Values.controller.service.internal.loadBalancerIP }}
 {{- end }}
-  {{- with .Values.controller.service.internal.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges: {{ toYaml . | nindent 2 }}
-  {{- end }}
+{{- if .Values.controller.service.internal.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toYaml .Values.controller.service.internal.loadBalancerSourceRanges | nindent 4 }}
+{{- end }}
   ports:
   - name: http
     port: {{ .Values.controller.service.internal.ports.http }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.service.internal.enabled }}
+{{- if and .Values.controller.service.enabled .Values.controller.service.internal.enabled}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -45,12 +45,13 @@ spec:
   externalTrafficPolicy: {{ .Values.controller.service.internal.externalTrafficPolicy }}
 {{- end }}
   ports:
+  {{- $setNodePorts := (eq .Values.controller.service.type "NodePort") }}
   {{- if .Values.controller.service.enableHttp }}
     - name: http
       port: {{ .Values.controller.service.ports.http }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.http }}
-    {{- if eq .Values.controller.service.type "NodePort" }}
+    {{- if (and $setNodePorts (not (empty .Values.controller.service.internal.nodePorts.http))) }}
       nodePort: {{ .Values.controller.service.internal.nodePorts.http }}
     {{- end }}
   {{- end }}
@@ -59,7 +60,7 @@ spec:
       port: {{ .Values.controller.service.ports.https }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.https }}
-    {{- if eq .Values.controller.service.type "NodePort" }}
+    {{- if (and $setNodePorts (not (empty .Values.controller.service.internal.nodePorts.https))) }}
       nodePort: {{ .Values.controller.service.internal.nodePorts.https }}
     {{- end }}
   {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -78,6 +78,9 @@ spec:
       port: {{ .Values.controller.service.ports.http }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.http }}
+    {{- if and (semverCompare ">=1.20" .Capabilities.KubeVersion.Version) (.Values.controller.service.appProtocol) }}
+      appProtocol: http
+    {{- end }}
     {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.http))) }}
       nodePort: {{ .Values.controller.service.nodePorts.http }}
     {{- end }}
@@ -87,6 +90,9 @@ spec:
       port: {{ .Values.controller.service.ports.https }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.https }}
+    {{- if and (semverCompare ">=1.20" .Capabilities.KubeVersion.Version) (.Values.controller.service.appProtocol) }}
+      appProtocol: https
+    {{- end }}
     {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.https))) }}
       nodePort: {{ .Values.controller.service.nodePorts.https }}
     {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -73,6 +73,7 @@ spec:
 {{- end }}
   ports:
   {{- $setNodePorts := (eq .Values.controller.service.type "NodePort") }}
+  {{- if .Values.controller.service.enableHttp }}
     - name: http
       port: {{ .Values.controller.service.ports.http }}
       protocol: TCP
@@ -80,6 +81,7 @@ spec:
     {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.http))) }}
       nodePort: {{ .Values.controller.service.nodePorts.http }}
     {{- end }}
+  {{- end }}
     - name: https
       port: {{ .Values.controller.service.ports.https }}
       protocol: TCP

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -66,6 +66,11 @@ spec:
   ipFamilyPolicy: {{ .Values.controller.service.ipFamilyPolicy }}
 {{- end }}
 {{- end }}
+{{- if semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version -}}
+{{- if .Values.controller.service.ipFamilies }}
+  ipFamilies: {{ toYaml .Values.controller.service.ipFamilies | nindent 4 }}
+{{- end }}
+{{- end }}
   ports:
   - name: http
     port: {{ .Values.controller.service.ports.http }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -55,6 +55,9 @@ spec:
 {{- if .Values.controller.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.controller.service.externalTrafficPolicy }}
 {{- end }}
+{{- if .Values.controller.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.controller.service.sessionAffinity }}
+{{- end }}
   ports:
   - name: http
     port: {{ .Values.controller.service.ports.http }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -72,18 +72,19 @@ spec:
 {{- end }}
 {{- end }}
   ports:
+  {{- $setNodePorts := (eq .Values.controller.service.type "NodePort") }}
     - name: http
       port: {{ .Values.controller.service.ports.http }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.http }}
-    {{- if eq .Values.controller.service.type "NodePort" }}
+    {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.http))) }}
       nodePort: {{ .Values.controller.service.nodePorts.http }}
     {{- end }}
     - name: https
       port: {{ .Values.controller.service.ports.https }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.https }}
-    {{- if eq .Values.controller.service.type "NodePort" }}
+    {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.https))) }}
       nodePort: {{ .Values.controller.service.nodePorts.https }}
     {{- end }}
   selector:

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -82,6 +82,7 @@ spec:
       nodePort: {{ .Values.controller.service.nodePorts.http }}
     {{- end }}
   {{- end }}
+  {{- if .Values.controller.service.enableHttps }}
     - name: https
       port: {{ .Values.controller.service.ports.https }}
       protocol: TCP
@@ -89,6 +90,7 @@ spec:
     {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.https))) }}
       nodePort: {{ .Values.controller.service.nodePorts.https }}
     {{- end }}
+  {{- end }}
   selector:
     {{- include "ingress-nginx.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: controller

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -72,19 +72,19 @@ spec:
 {{- end }}
 {{- end }}
   ports:
-  - name: http
-    port: {{ .Values.controller.service.ports.http }}
-    protocol: TCP
-    targetPort: {{ .Values.controller.service.targetPorts.http }}
+    - name: http
+      port: {{ .Values.controller.service.ports.http }}
+      protocol: TCP
+      targetPort: {{ .Values.controller.service.targetPorts.http }}
     {{- if eq .Values.controller.service.type "NodePort" }}
-    nodePort: {{ .Values.controller.service.nodePorts.http }}
+      nodePort: {{ .Values.controller.service.nodePorts.http }}
     {{- end }}
-  - name: https
-    port: {{ .Values.controller.service.ports.https }}
-    protocol: TCP
-    targetPort: {{ .Values.controller.service.targetPorts.https }}
+    - name: https
+      port: {{ .Values.controller.service.ports.https }}
+      protocol: TCP
+      targetPort: {{ .Values.controller.service.targetPorts.https }}
     {{- if eq .Values.controller.service.type "NodePort" }}
-    nodePort: {{ .Values.controller.service.nodePorts.https }}
+      nodePort: {{ .Values.controller.service.nodePorts.https }}
     {{- end }}
   selector:
     {{- include "ingress-nginx.selectorLabels" . | nindent 4 }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -23,7 +23,6 @@ metadata:
     {{- end }}
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
   {{- else if eq .Values.provider "azure" }}
-    # this annotation adds lb rules for both TCP and UDP to allow UDP outbound connection with Standard LB
     service.beta.kubernetes.io/azure-load-balancer-mixed-protocols: "true"
     {{- if not .Values.controller.service.public }}
     service.beta.kubernetes.io/azure-load-balancer-internal: "true"

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -30,14 +30,14 @@ metadata:
     {{- end }}
   {{- end }}
   {{- end }}
-  name: {{ include "resource.controller-service.name" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
   {{- if .Values.controller.service.labels }}
     {{- toYaml .Values.controller.service.labels | nindent 4 }}
   {{- end }}
+  name: {{ include "resource.controller-service.name" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   type: {{ .Values.controller.service.type }}
   {{- with .Values.controller.service.loadBalancerSourceRanges }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -49,9 +49,9 @@ spec:
 {{- if .Values.controller.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.controller.service.loadBalancerIP }}
 {{- end }}
-  {{- with .Values.controller.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges: {{ toYaml . | nindent 2 }}
-  {{- end }}
+{{- if .Values.controller.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toYaml .Values.controller.service.loadBalancerSourceRanges | nindent 4 }}
+{{- end }}
   ports:
   - name: http
     port: {{ .Values.controller.service.ports.http }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -52,6 +52,9 @@ spec:
 {{- if .Values.controller.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{ toYaml .Values.controller.service.loadBalancerSourceRanges | nindent 4 }}
 {{- end }}
+{{- if .Values.controller.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.controller.service.externalTrafficPolicy }}
+{{- end }}
   ports:
   - name: http
     port: {{ .Values.controller.service.ports.http }}
@@ -70,7 +73,4 @@ spec:
   selector:
     {{- include "ingress-nginx.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: controller
-  {{- if .Values.controller.service.externalTrafficPolicy }}
-  externalTrafficPolicy: {{ .Values.controller.service.externalTrafficPolicy }}
-  {{- end }}
 {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.service.enabled }}
+{{- if and .Values.controller.service.enabled .Values.controller.service.external.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -43,6 +43,9 @@ spec:
 {{- if .Values.controller.service.clusterIP }}
   clusterIP: {{ .Values.controller.service.clusterIP }}
 {{- end }}
+{{- if .Values.controller.service.externalIPs }}
+  externalIPs: {{ toYaml .Values.controller.service.externalIPs | nindent 4 }}
+{{- end }}
   {{- with .Values.controller.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{ toYaml . | nindent 2 }}
   {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -97,6 +97,28 @@ spec:
       nodePort: {{ .Values.controller.service.nodePorts.https }}
     {{- end }}
   {{- end }}
+  {{- range $key, $value := .Values.tcp }}
+    - name: {{ if $.Values.portNamePrefix }}{{ $.Values.portNamePrefix }}-{{ end }}{{ $key }}-tcp
+      port: {{ $key }}
+      protocol: TCP
+      targetPort: {{ if $.Values.portNamePrefix }}{{ $.Values.portNamePrefix }}-{{ end }}{{ $key }}-tcp
+    {{- if $.Values.controller.service.nodePorts.tcp }}
+    {{- if index $.Values.controller.service.nodePorts.tcp $key }}
+      nodePort: {{ index $.Values.controller.service.nodePorts.tcp $key }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- range $key, $value := .Values.udp }}
+    - name: {{ if $.Values.portNamePrefix }}{{ $.Values.portNamePrefix }}-{{ end }}{{ $key }}-udp
+      port: {{ $key }}
+      protocol: UDP
+      targetPort: {{ if $.Values.portNamePrefix }}{{ $.Values.portNamePrefix }}-{{ end }}{{ $key }}-udp
+    {{- if $.Values.controller.service.nodePorts.udp }}
+    {{- if index $.Values.controller.service.nodePorts.udp $key }}
+      nodePort: {{ index $.Values.controller.service.nodePorts.udp $key }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
   selector:
     {{- include "ingress-nginx.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: controller

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -46,6 +46,9 @@ spec:
 {{- if .Values.controller.service.externalIPs }}
   externalIPs: {{ toYaml .Values.controller.service.externalIPs | nindent 4 }}
 {{- end }}
+{{- if .Values.controller.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.controller.service.loadBalancerIP }}
+{{- end }}
   {{- with .Values.controller.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{ toYaml . | nindent 2 }}
   {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -58,6 +58,9 @@ spec:
 {{- if .Values.controller.service.sessionAffinity }}
   sessionAffinity: {{ .Values.controller.service.sessionAffinity }}
 {{- end }}
+{{- if .Values.controller.service.healthCheckNodePort }}
+  healthCheckNodePort: {{ .Values.controller.service.healthCheckNodePort }}
+{{- end }}
   ports:
   - name: http
     port: {{ .Values.controller.service.ports.http }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -40,6 +40,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   type: {{ .Values.controller.service.type }}
+{{- if .Values.controller.service.clusterIP }}
+  clusterIP: {{ .Values.controller.service.clusterIP }}
+{{- end }}
   {{- with .Values.controller.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{ toYaml . | nindent 2 }}
   {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -61,6 +61,11 @@ spec:
 {{- if .Values.controller.service.healthCheckNodePort }}
   healthCheckNodePort: {{ .Values.controller.service.healthCheckNodePort }}
 {{- end }}
+{{- if semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version -}}
+{{- if .Values.controller.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.controller.service.ipFamilyPolicy }}
+{{- end }}
+{{- end }}
   ports:
   - name: http
     port: {{ .Values.controller.service.ports.http }}

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -733,9 +733,6 @@
                                 "ports": {
                                     "type": "object",
                                     "properties": {
-                                        "http": {
-                                            "type": "integer"
-                                        },
                                         "https": {
                                             "type": "integer"
                                         }

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -735,6 +735,12 @@
                                 }
                             }
                         },
+                        "ipFamilies": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
                         "ipFamilyPolicy": {
                             "type": "string",
                             "pattern": "(SingleStack|PreferDualStack|RequireDualStack)"

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -727,6 +727,12 @@
                                         },
                                         "https": {
                                             "type": "integer"
+                                        },
+                                        "tcp": {
+                                            "type": "object"
+                                        },
+                                        "udp": {
+                                            "type": "object"
                                         }
                                     }
                                 },

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -743,9 +743,6 @@
                                 },
                                 "suffix": {
                                     "type": "string"
-                                },
-                                "type": {
-                                    "type": "string"
                                 }
                             }
                         },

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -713,6 +713,9 @@
                                     "type": "string",
                                     "pattern": "(Local|Cluster)"
                                 },
+                                "loadBalancerIP": {
+                                    "type": "string"
+                                },
                                 "loadBalancerSourceRanges": {
                                     "type": "array"
                                 },

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -766,6 +766,10 @@
                         "public": {
                             "type": "boolean"
                         },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "pattern": "(None|ClientIP)"
+                        },
                         "subdomain": {
                             "type": "string"
                         },

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -713,9 +713,6 @@
                                     "type": "string",
                                     "pattern": "(Local|Cluster)"
                                 },
-                                "labels": {
-                                    "type": "object"
-                                },
                                 "loadBalancerSourceRanges": {
                                     "type": "array"
                                 },

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -656,6 +656,9 @@
                         "annotations": {
                             "type": "object"
                         },
+                        "clusterIP": {
+                            "type": "string"
+                        },
                         "enabled": {
                             "type": "boolean"
                         },

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -735,6 +735,10 @@
                                 }
                             }
                         },
+                        "ipFamilyPolicy": {
+                            "type": "string",
+                            "pattern": "(SingleStack|PreferDualStack|RequireDualStack)"
+                        },
                         "labels": {
                             "type": "object"
                         },

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -659,6 +659,9 @@
                         "clusterIP": {
                             "type": "string"
                         },
+                        "enableHttp": {
+                            "type": "boolean"
+                        },
                         "enabled": {
                             "type": "boolean"
                         },

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -735,6 +735,9 @@
                         "labels": {
                             "type": "object"
                         },
+                        "loadBalancerIP": {
+                            "type": "string"
+                        },
                         "loadBalancerSourceRanges": {
                             "type": "array"
                         },

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -680,6 +680,9 @@
                             "type": "string",
                             "pattern": "(Local|Cluster)"
                         },
+                        "healthCheckNodePort": {
+                            "type": "integer"
+                        },
                         "internal": {
                             "type": "object",
                             "properties": {

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -673,6 +673,9 @@
                                 }
                             }
                         },
+                        "externalIPs": {
+                            "type": "array"
+                        },
                         "externalTrafficPolicy": {
                             "type": "string",
                             "pattern": "(Local|Cluster)"

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -730,14 +730,6 @@
                                         }
                                     }
                                 },
-                                "ports": {
-                                    "type": "object",
-                                    "properties": {
-                                        "https": {
-                                            "type": "integer"
-                                        }
-                                    }
-                                },
                                 "subdomain": {
                                     "type": "string"
                                 },

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -1146,6 +1146,9 @@
                 }
             }
         },
+        "portNamePrefix": {
+            "type": "string"
+        },
         "provider": {
             "type": "string"
         },

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -656,6 +656,9 @@
                         "annotations": {
                             "type": "object"
                         },
+                        "appProtocol": {
+                            "type": "boolean"
+                        },
                         "clusterIP": {
                             "type": "string"
                         },

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -671,6 +671,14 @@
                         "enabled": {
                             "type": "boolean"
                         },
+                        "external": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
                         "externalDNS": {
                             "type": "object",
                             "properties": {

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -662,6 +662,9 @@
                         "enableHttp": {
                             "type": "boolean"
                         },
+                        "enableHttps": {
+                            "type": "boolean"
+                        },
                         "enabled": {
                             "type": "boolean"
                         },

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -779,6 +779,12 @@
                                 },
                                 "https": {
                                     "type": "integer"
+                                },
+                                "tcp": {
+                                    "type": "object"
+                                },
+                                "udp": {
+                                    "type": "object"
                                 }
                             }
                         },

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -602,10 +602,16 @@ controller:
       # By default any source IP address can connect to the service.
       loadBalancerSourceRanges: []
 
-      # type: NodePort
+      ## nodePorts:
+      ##   http: 31080
+      ##   https: 31443
+      ##   tcp:
+      ##     8080: 31808
       nodePorts:
         http: 30012
         https: 30013
+        tcp: {}
+        udp: {}
 
   admissionWebhooks:
     annotations: {}

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -583,7 +583,6 @@ controller:
       suffix: ""
 
       annotations: {}
-      labels: {}
 
       # controller.service.internal.externalTrafficPolicy
       # Configures kube-proxy, denotes if this Service desires to have external traffic routed to node-local or cluster-wide endpoints

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -603,7 +603,6 @@ controller:
       loadBalancerSourceRanges: []
 
       ports:
-        http: 80
         https: 443
 
       # type: NodePort

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -547,22 +547,24 @@ controller:
     # Configures external dns subdomain to be appeneded to base domain in definition of cloud load balancer's fully qualified hostname.
     subdomain: "ingress"
 
-    # controller.service.type
-    # Valid values: LoadBalancer, NodePort
-    type: LoadBalancer
-
     ports:
       http: 80
       https: 443
-
     targetPorts:
       http: http
       https: https
-
-    # type: NodePort
+    type: LoadBalancer
+    ## type: NodePort
+    ## nodePorts:
+    ##   http: 32080
+    ##   https: 32443
+    ##   tcp:
+    ##     8080: 32808
     nodePorts:
       http: 30010
       https: 30011
+      tcp: {}
+      udp: {}
     external:
       enabled: true
 

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -563,6 +563,8 @@ controller:
     nodePorts:
       http: 30010
       https: 30011
+    external:
+      enabled: true
 
     # controller.service.internal
     # Configuration settings for `-internal` suffixed Service variant.

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -482,6 +482,13 @@ controller:
     # and the namespace of the Service.
     suffix: ""
 
+    # -- If enabled is adding an appProtocol option for Kubernetes service. An appProtocol field replacing annotations that were
+    # using for setting a backend protocol. Here is an example for AWS: service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
+    # It allows choosing the protocol for each backend specified in the Kubernetes service.
+    # See the following GitHub issue for more details about the purpose: https://github.com/kubernetes/kubernetes/issues/40244
+    # Will be ignored for Kubernetes versions older than 1.20
+    ##
+    appProtocol: true
     annotations: {}
     labels: {}
     # clusterIP: ""

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -493,6 +493,7 @@ controller:
     # -- Used by cloud providers to connect the resulting `LoadBalancer` to a pre-existing static IP according to https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
+    enableHttp: true
     ## Set external traffic policy to: "Local" to preserve source IP on providers supporting it.
     ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
     externalTrafficPolicy: "Local"

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -486,6 +486,11 @@ controller:
     labels: {}
     # clusterIP: ""
 
+    # -- List of IP addresses at which the controller services are available
+    ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+    ##
+    externalIPs: []
+
     # controller.externalDNS
     externalDNS:
 

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -492,6 +492,7 @@ controller:
     externalIPs: []
     # -- Used by cloud providers to connect the resulting `LoadBalancer` to a pre-existing static IP according to https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
     loadBalancerIP: ""
+    loadBalancerSourceRanges: []
 
     # controller.externalDNS
     externalDNS:
@@ -523,12 +524,6 @@ controller:
     # controller.service.type
     # Valid values: LoadBalancer, NodePort
     type: LoadBalancer
-
-    # controller.service.loadBalancerSourceRanges
-    # Configures the source IP address ranges which can connect to the service.
-    # Keep in mind that some solutions need to access the service to work properly (e.g. cert-manager & Let's Encrypt).
-    # By default any source IP address can connect to the service.
-    loadBalancerSourceRanges: []
 
     ports:
       http: 80

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -494,6 +494,7 @@ controller:
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
     enableHttp: true
+    enableHttps: true
     ## Set external traffic policy to: "Local" to preserve source IP on providers supporting it.
     ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
     externalTrafficPolicy: "Local"

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -468,12 +468,7 @@ controller:
   # The groupID that the container will run as.
   groupID: 101
 
-  # controller.service
   service:
-
-    # controller.service.enabled
-    # If true, create LoadBalancer Service. Dynamically calculated during cluster creation.
-    # Do not overwrite this value.
     enabled: true
 
     # controller.service.suffix
@@ -567,13 +562,8 @@ controller:
       udp: {}
     external:
       enabled: true
-
-    # controller.service.internal
-    # Configuration settings for `-internal` suffixed Service variant.
-    # This second Service partially covers use case and need for multiple ingress controllers, providing separate IPs for public and internal traffic in single app.
     internal:
-
-      # controller.service.internal.enabled
+      # -- Enables an additional internal load balancer (besides the external one).
       enabled: false
 
       # controller.service.internal.suffix
@@ -582,25 +572,21 @@ controller:
       # and the namespace of the Service.
       suffix: ""
 
+      # -- Annotations are mandatory for the load balancer to come up. Varies with the cloud service.
       annotations: {}
       # loadBalancerIP: ""
-
-      # controller.service.internal.externalTrafficPolicy
-      # Configures kube-proxy, denotes if this Service desires to have external traffic routed to node-local or cluster-wide endpoints
-      #   Local - kube-proxy only proxies requests to local endpoints (does not forward traffic to other nodes), source IP preserved
-      #   Cluster - kube-proxy proxies requests randomly across all endpoints (forwards traffic to other nodes if necessary), source IP NAT'd
-      externalTrafficPolicy: "Local"
 
       # controller.service.internal.subdomain
       # Applies to clusters running on AWS or Azure.
       # Configures external dns subdomain to be appeneded to base domain in definition of cloud load balancer's fully qualified hostname.
       subdomain: "ingress-internal"
 
-      # controller.service.internal.loadBalancerSourceRanges
-      # Configures the source IP address ranges which can connect to the service.
-      # Keep in mind that some solutions need to access the service to work properly (e.g. cert-manager & Let's Encrypt).
-      # By default any source IP address can connect to the service.
+      # -- Restrict access For LoadBalancer service. Defaults to 0.0.0.0/0.
       loadBalancerSourceRanges: []
+      ## Set external traffic policy to: "Local" to preserve source IP on
+      ## providers supporting it
+      ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
+      externalTrafficPolicy: "Local"
 
       ## nodePorts:
       ##   http: 31080

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -940,6 +940,9 @@ tcp: {}
 udp: {}
 #  53: "kube-system/kube-dns:53"
 
+# -- Prefix for TCP and UDP ports names in ingress controller service
+## Some cloud providers, like Yandex Cloud may have a requirements for a port name regex to support cloud load balancer integration
+portNamePrefix: ""
 # -- (string) A base64-encoded Diffie-Hellman parameter.
 # This can be generated with: `openssl dhparam 4096 2> /dev/null | base64`
 ## Ref: https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/ssl-dh-param

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -497,6 +497,10 @@ controller:
     ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
     externalTrafficPolicy: "Local"
 
+    ## Must be either "None" or "ClientIP" if set. Kubernetes will default to "None".
+    ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+    # sessionAffinity: ""
+
     # controller.externalDNS
     externalDNS:
 

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -501,6 +501,11 @@ controller:
     ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
     # sessionAffinity: ""
 
+    ## Specifies the health check node port (numeric port number) for the service. If healthCheckNodePort isn’t specified,
+    ## the service controller allocates a port from your cluster’s NodePort range.
+    ## Ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+    # healthCheckNodePort: 0
+
     # controller.externalDNS
     externalDNS:
 

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -511,6 +511,11 @@ controller:
     # The ipFamilies and clusterIPs fields depend on the value of this field.
     ## Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/
     ipFamilyPolicy: "SingleStack"
+    # -- List of IP families (e.g. IPv4, IPv6) assigned to the service. This field is usually assigned automatically
+    # based on cluster configuration and the ipFamilyPolicy field.
+    ## Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/
+    ipFamilies:
+      - IPv4
 
     # controller.externalDNS
     externalDNS:

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -493,6 +493,9 @@ controller:
     # -- Used by cloud providers to connect the resulting `LoadBalancer` to a pre-existing static IP according to https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
+    ## Set external traffic policy to: "Local" to preserve source IP on providers supporting it.
+    ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
+    externalTrafficPolicy: "Local"
 
     # controller.externalDNS
     externalDNS:
@@ -504,12 +507,6 @@ controller:
       # controller.externalDNS.enabled
       # Indicates whether to set external-dns annotations on the LB service.
       enabled: true
-
-    # controller.service.externalTrafficPolicy
-    # Configures kube-proxy, denotes if this Service desires to have external traffic routed to node-local or cluster-wide endpoints
-    #   Local - kube-proxy only proxies requests to local endpoints (does not forward traffic to other nodes), source IP preserved
-    #   Cluster - kube-proxy proxies requests randomly across all endpoints (forwards traffic to other nodes if necessary), source IP NAT'd
-    externalTrafficPolicy: "Local"
 
     # controller.service.public
     # Applies to clusters running on AWS or Azure.

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -595,9 +595,6 @@ controller:
       # Configures external dns subdomain to be appeneded to base domain in definition of cloud load balancer's fully qualified hostname.
       subdomain: "ingress-internal"
 
-      # controller.service.internal.type
-      type: LoadBalancer
-
       # controller.service.internal.loadBalancerSourceRanges
       # Configures the source IP address ranges which can connect to the service.
       # Keep in mind that some solutions need to access the service to work properly (e.g. cert-manager & Let's Encrypt).

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -602,9 +602,6 @@ controller:
       # By default any source IP address can connect to the service.
       loadBalancerSourceRanges: []
 
-      ports:
-        https: 443
-
       # type: NodePort
       nodePorts:
         http: 30012

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -583,6 +583,7 @@ controller:
       suffix: ""
 
       annotations: {}
+      # loadBalancerIP: ""
 
       # controller.service.internal.externalTrafficPolicy
       # Configures kube-proxy, denotes if this Service desires to have external traffic routed to node-local or cluster-wide endpoints

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -484,6 +484,7 @@ controller:
 
     annotations: {}
     labels: {}
+    # clusterIP: ""
 
     # controller.externalDNS
     externalDNS:

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -490,6 +490,8 @@ controller:
     ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
     ##
     externalIPs: []
+    # -- Used by cloud providers to connect the resulting `LoadBalancer` to a pre-existing static IP according to https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+    loadBalancerIP: ""
 
     # controller.externalDNS
     externalDNS:

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -506,6 +506,12 @@ controller:
     ## Ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     # healthCheckNodePort: 0
 
+    # -- Represents the dual-stack-ness requested or required by this Service. Possible values are
+    # SingleStack, PreferDualStack or RequireDualStack.
+    # The ipFamilies and clusterIPs fields depend on the value of this field.
+    ## Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/
+    ipFamilyPolicy: "SingleStack"
+
     # controller.externalDNS
     externalDNS:
 


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version | ✓ | ✓ |  |
| Existing Ingress resources are reconciled correctly | ✓ | ✓ |  |
| Fresh install | ✓ | ✓ |  |
| Fresh Ingress resources are reconciled correctly | ✓ | ✓ |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
