### PR TITLE
Chart: Add CI values from upstream.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Chart: Align to upstream. ([#431](https://github.com/giantswarm/nginx-ingress-controller-app/pull/431))
   - Chart: Add `.helmignore`.
   - Chart: Add `NOTES.txt`.
+- Chart: Add CI values from upstream. ([#432](https://github.com/giantswarm/nginx-ingress-controller-app/pull/432))
 
 ### Changed
 

--- a/helm/nginx-ingress-controller-app/ci/controller-admission-tls-cert-manager-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/controller-admission-tls-cert-manager-values.yaml
@@ -1,0 +1,6 @@
+controller:
+  admissionWebhooks:
+    certManager:
+      enabled: true
+  service:
+    type: ClusterIP

--- a/helm/nginx-ingress-controller-app/ci/controller-custom-ingressclass-flags.yaml
+++ b/helm/nginx-ingress-controller-app/ci/controller-custom-ingressclass-flags.yaml
@@ -1,0 +1,7 @@
+controller:
+  watchIngressWithoutClass: true
+  ingressClassResource:
+    name: custom-nginx
+    enabled: true
+    default: true
+    controllerValue: "k8s.io/custom-nginx"

--- a/helm/nginx-ingress-controller-app/ci/daemonset-customconfig-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/daemonset-customconfig-values.yaml
@@ -1,0 +1,14 @@
+controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  kind: DaemonSet
+  allowSnippetAnnotations: false
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP
+
+  config:
+    use-proxy-protocol: "true"

--- a/helm/nginx-ingress-controller-app/ci/daemonset-customnodeport-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/daemonset-customnodeport-values.yaml
@@ -1,0 +1,22 @@
+controller:
+  kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: false
+
+  service:
+    type: NodePort
+    nodePorts:
+      tcp:
+        9000: 30090
+      udp:
+        9001: 30091
+
+tcp:
+  9000: "default/test:8080"
+
+udp:
+  9001: "default/test:8080"

--- a/helm/nginx-ingress-controller-app/ci/daemonset-extra-modules.yaml
+++ b/helm/nginx-ingress-controller-app/ci/daemonset-extra-modules.yaml
@@ -1,0 +1,10 @@
+controller:
+  kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+  service:
+    type: ClusterIP
+  extraModules:
+    - name: opentelemetry
+      image: busybox

--- a/helm/nginx-ingress-controller-app/ci/daemonset-headers-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/daemonset-headers-values.yaml
@@ -1,0 +1,14 @@
+controller:
+  kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: false
+  addHeaders:
+    X-Frame-Options: deny
+  proxySetHeaders:
+    X-Forwarded-Proto: https
+  service:
+    type: ClusterIP

--- a/helm/nginx-ingress-controller-app/ci/daemonset-internal-lb-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/daemonset-internal-lb-values.yaml
@@ -1,0 +1,14 @@
+controller:
+  kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP
+    internal:
+      enabled: true
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-internal: "true"

--- a/helm/nginx-ingress-controller-app/ci/daemonset-nodeport-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/daemonset-nodeport-values.yaml
@@ -1,0 +1,10 @@
+controller:
+  kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: NodePort

--- a/helm/nginx-ingress-controller-app/ci/daemonset-podannotations-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/daemonset-podannotations-values.yaml
@@ -1,0 +1,17 @@
+controller:
+  kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: false
+  metrics:
+    enabled: true
+  service:
+    type: ClusterIP
+  podAnnotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "10254"
+    prometheus.io/scheme: http
+    prometheus.io/scrape: "true"

--- a/helm/nginx-ingress-controller-app/ci/daemonset-tcp-udp-configMapNamespace-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/daemonset-tcp-udp-configMapNamespace-values.yaml
@@ -1,0 +1,20 @@
+controller:
+  kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP
+  tcp:
+    configMapNamespace: default
+  udp:
+    configMapNamespace: default
+
+tcp:
+  9000: "default/test:8080"
+
+udp:
+  9001: "default/test:8080"

--- a/helm/nginx-ingress-controller-app/ci/daemonset-tcp-udp-portNamePrefix-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/daemonset-tcp-udp-portNamePrefix-values.yaml
@@ -1,0 +1,18 @@
+controller:
+  kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP
+
+tcp:
+  9000: "default/test:8080"
+
+udp:
+  9001: "default/test:8080"
+
+portNamePrefix: "port"

--- a/helm/nginx-ingress-controller-app/ci/daemonset-tcp-udp-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/daemonset-tcp-udp-values.yaml
@@ -1,0 +1,16 @@
+controller:
+  kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP
+
+tcp:
+  9000: "default/test:8080"
+
+udp:
+  9001: "default/test:8080"

--- a/helm/nginx-ingress-controller-app/ci/daemonset-tcp-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/daemonset-tcp-values.yaml
@@ -1,0 +1,14 @@
+controller:
+  kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP
+
+tcp:
+  9000: "default/test:8080"
+  9001: "default/test:8080"

--- a/helm/nginx-ingress-controller-app/ci/deamonset-default-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deamonset-default-values.yaml
@@ -1,0 +1,10 @@
+controller:
+  kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP

--- a/helm/nginx-ingress-controller-app/ci/deamonset-metrics-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deamonset-metrics-values.yaml
@@ -1,0 +1,12 @@
+controller:
+  kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: false
+  metrics:
+    enabled: true
+  service:
+    type: ClusterIP

--- a/helm/nginx-ingress-controller-app/ci/deamonset-psp-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deamonset-psp-values.yaml
@@ -1,0 +1,13 @@
+controller:
+  kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP
+
+podSecurityPolicy:
+  enabled: true

--- a/helm/nginx-ingress-controller-app/ci/deamonset-webhook-and-psp-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deamonset-webhook-and-psp-values.yaml
@@ -1,0 +1,13 @@
+controller:
+  kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: true
+  service:
+    type: ClusterIP
+
+podSecurityPolicy:
+  enabled: true

--- a/helm/nginx-ingress-controller-app/ci/deamonset-webhook-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deamonset-webhook-values.yaml
@@ -1,0 +1,10 @@
+controller:
+  kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: true
+  service:
+    type: ClusterIP

--- a/helm/nginx-ingress-controller-app/ci/deployment-autoscaling-behavior-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deployment-autoscaling-behavior-values.yaml
@@ -1,0 +1,14 @@
+controller:
+  autoscaling:
+    enabled: true
+    behavior:
+      scaleDown:
+        stabilizationWindowSeconds: 300
+        policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 180
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP

--- a/helm/nginx-ingress-controller-app/ci/deployment-autoscaling-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deployment-autoscaling-values.yaml
@@ -1,0 +1,11 @@
+controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  autoscaling:
+    enabled: true
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP

--- a/helm/nginx-ingress-controller-app/ci/deployment-customconfig-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deployment-customconfig-values.yaml
@@ -1,0 +1,12 @@
+controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  config:
+    use-proxy-protocol: "true"
+  allowSnippetAnnotations: false
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP

--- a/helm/nginx-ingress-controller-app/ci/deployment-customnodeport-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deployment-customnodeport-values.yaml
@@ -1,0 +1,20 @@
+controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: NodePort
+    nodePorts:
+      tcp:
+        9000: 30090
+      udp:
+        9001: 30091
+
+tcp:
+  9000: "default/test:8080"
+
+udp:
+  9001: "default/test:8080"

--- a/helm/nginx-ingress-controller-app/ci/deployment-default-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deployment-default-values.yaml
@@ -1,0 +1,8 @@
+# Left blank to test default values
+controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  service:
+    type: ClusterIP

--- a/helm/nginx-ingress-controller-app/ci/deployment-extra-modules-default-container-sec-context.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deployment-extra-modules-default-container-sec-context.yaml
@@ -1,0 +1,12 @@
+controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  service:
+    type: ClusterIP
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+  extraModules:
+    - name: opentelemetry
+      image: busybox

--- a/helm/nginx-ingress-controller-app/ci/deployment-extra-modules-specific-container-sec-context.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deployment-extra-modules-specific-container-sec-context.yaml
@@ -1,0 +1,12 @@
+controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  service:
+    type: ClusterIP
+  extraModules:
+    - name: opentelemetry
+      image: busybox
+      containerSecurityContext:
+        allowPrivilegeEscalation: false

--- a/helm/nginx-ingress-controller-app/ci/deployment-extra-modules.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deployment-extra-modules.yaml
@@ -1,0 +1,10 @@
+controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  service:
+    type: ClusterIP
+  extraModules:
+    - name: opentelemetry
+      image: busybox

--- a/helm/nginx-ingress-controller-app/ci/deployment-headers-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deployment-headers-values.yaml
@@ -1,0 +1,13 @@
+controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: false
+  addHeaders:
+    X-Frame-Options: deny
+  proxySetHeaders:
+    X-Forwarded-Proto: https
+  service:
+    type: ClusterIP

--- a/helm/nginx-ingress-controller-app/ci/deployment-internal-lb-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deployment-internal-lb-values.yaml
@@ -1,0 +1,13 @@
+controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP
+    internal:
+      enabled: true
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-internal: "true"

--- a/helm/nginx-ingress-controller-app/ci/deployment-metrics-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deployment-metrics-values.yaml
@@ -1,0 +1,11 @@
+controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: false
+  metrics:
+    enabled: true
+  service:
+    type: ClusterIP

--- a/helm/nginx-ingress-controller-app/ci/deployment-nodeport-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deployment-nodeport-values.yaml
@@ -1,0 +1,9 @@
+controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: NodePort

--- a/helm/nginx-ingress-controller-app/ci/deployment-podannotations-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deployment-podannotations-values.yaml
@@ -1,0 +1,16 @@
+controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: false
+  metrics:
+    enabled: true
+  service:
+    type: ClusterIP
+  podAnnotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "10254"
+    prometheus.io/scheme: http
+    prometheus.io/scrape: "true"

--- a/helm/nginx-ingress-controller-app/ci/deployment-psp-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deployment-psp-values.yaml
@@ -1,0 +1,10 @@
+controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  service:
+    type: ClusterIP
+
+podSecurityPolicy:
+  enabled: true

--- a/helm/nginx-ingress-controller-app/ci/deployment-tcp-udp-configMapNamespace-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deployment-tcp-udp-configMapNamespace-values.yaml
@@ -1,0 +1,19 @@
+controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP
+  tcp:
+    configMapNamespace: default
+  udp:
+    configMapNamespace: default
+
+tcp:
+  9000: "default/test:8080"
+
+udp:
+  9001: "default/test:8080"

--- a/helm/nginx-ingress-controller-app/ci/deployment-tcp-udp-portNamePrefix-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deployment-tcp-udp-portNamePrefix-values.yaml
@@ -1,0 +1,17 @@
+controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP
+
+tcp:
+  9000: "default/test:8080"
+
+udp:
+  9001: "default/test:8080"
+
+portNamePrefix: "port"

--- a/helm/nginx-ingress-controller-app/ci/deployment-tcp-udp-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deployment-tcp-udp-values.yaml
@@ -1,0 +1,15 @@
+controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP
+
+tcp:
+  9000: "default/test:8080"
+
+udp:
+  9001: "default/test:8080"

--- a/helm/nginx-ingress-controller-app/ci/deployment-tcp-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deployment-tcp-values.yaml
@@ -1,0 +1,11 @@
+controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  service:
+    type: ClusterIP
+
+tcp:
+  9000: "default/test:8080"
+  9001: "default/test:8080"

--- a/helm/nginx-ingress-controller-app/ci/deployment-webhook-and-psp-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deployment-webhook-and-psp-values.yaml
@@ -1,0 +1,12 @@
+controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: true
+  service:
+    type: ClusterIP
+
+podSecurityPolicy:
+  enabled: true

--- a/helm/nginx-ingress-controller-app/ci/deployment-webhook-extraEnvs-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deployment-webhook-extraEnvs-values.yaml
@@ -1,0 +1,12 @@
+controller:
+  service:
+    type: ClusterIP
+  admissionWebhooks:
+    enabled: true
+    extraEnvs:
+      - name: FOO
+        value: foo
+      - name: TEST
+        value: test
+    patch:
+      enabled: true

--- a/helm/nginx-ingress-controller-app/ci/deployment-webhook-resources-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deployment-webhook-resources-values.yaml
@@ -1,0 +1,23 @@
+controller:
+  service:
+    type: ClusterIP
+  admissionWebhooks:
+    enabled: true
+    createSecretJob:
+      resources:
+        limits:
+          cpu: 10m
+          memory: 20Mi
+        requests:
+          cpu: 10m
+          memory: 20Mi
+    patchWebhookJob:
+      resources:
+        limits:
+          cpu: 10m
+          memory: 20Mi
+        requests:
+          cpu: 10m
+          memory: 20Mi
+    patch:
+      enabled: true

--- a/helm/nginx-ingress-controller-app/ci/deployment-webhook-values.yaml
+++ b/helm/nginx-ingress-controller-app/ci/deployment-webhook-values.yaml
@@ -1,0 +1,9 @@
+controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: true
+  service:
+    type: ClusterIP


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version |  |  |  |
| Existing Ingress resources are reconciled correctly |  |  |  |
| Fresh install |  |  |  |
| Fresh Ingress resources are reconciled correctly |  |  |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
