### PR TITLE
Service: Remove `controller.service.suffix` & `controller.service.internal.suffix`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Removed
 
+- Service: Remove `controller.service.suffix` & `controller.service.internal.suffix`. ([#448](https://github.com/giantswarm/nginx-ingress-controller-app/pull/448))\
+  **NOTE:** This is part of our alignment to upstream. There is no replacement for this key.
 - Deployment/DaemonSet: Remove `cluster-autoscaler.kubernetes.io/safe-to-evict` annotation. ([#449](https://github.com/giantswarm/nginx-ingress-controller-app/pull/449))
 - Params: Align to upstream. ([#452](https://github.com/giantswarm/nginx-ingress-controller-app/pull/452))
   - Params: Remove `controller.annotationsPrefix`.\

--- a/helm/nginx-ingress-controller-app/README.md
+++ b/helm/nginx-ingress-controller-app/README.md
@@ -295,7 +295,6 @@ Please ensure that cert-manager is correctly installed and configured.
 | controller.service.internal.nodePorts.tcp | object | `{}` |  |
 | controller.service.internal.nodePorts.udp | object | `{}` |  |
 | controller.service.internal.subdomain | string | `"ingress-internal"` |  |
-| controller.service.internal.suffix | string | `""` |  |
 | controller.service.ipFamilies | list | `["IPv4"]` | List of IP families (e.g. IPv4, IPv6) assigned to the service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. # Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/ |
 | controller.service.ipFamilyPolicy | string | `"SingleStack"` | Represents the dual-stack-ness requested or required by this Service. Possible values are SingleStack, PreferDualStack or RequireDualStack. The ipFamilies and clusterIPs fields depend on the value of this field. # Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/ |
 | controller.service.labels | object | `{}` |  |
@@ -309,7 +308,6 @@ Please ensure that cert-manager is correctly installed and configured.
 | controller.service.ports.https | int | `443` |  |
 | controller.service.public | bool | `true` |  |
 | controller.service.subdomain | string | `"ingress"` |  |
-| controller.service.suffix | string | `""` |  |
 | controller.service.targetPorts.http | string | `"http"` |  |
 | controller.service.targetPorts.https | string | `"https"` |  |
 | controller.service.type | string | `"LoadBalancer"` |  |

--- a/helm/nginx-ingress-controller-app/templates/_params.tpl
+++ b/helm/nginx-ingress-controller-app/templates/_params.tpl
@@ -5,9 +5,9 @@
 {{- end }}
 {{- if and .Values.controller.publishService.enabled .Values.controller.service.enabled }}
 {{- if .Values.controller.service.external.enabled }}
-- --publish-service={{ template "ingress-nginx.controller.publishServicePath" . }}{{ .Values.controller.service.suffix }}
+- --publish-service={{ template "ingress-nginx.controller.publishServicePath" . }}
 {{- else if .Values.controller.service.internal.enabled }}
-- --publish-service={{ template "ingress-nginx.controller.publishServicePath" . }}-internal{{ .Values.controller.service.internal.suffix }}
+- --publish-service={{ template "ingress-nginx.controller.publishServicePath" . }}-internal
 {{- end }}
 {{- end }}
 - --election-id={{ include "ingress-nginx.controller.electionID" . }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -33,7 +33,7 @@ metadata:
   {{- if .Values.controller.service.labels }}
     {{- toYaml .Values.controller.service.labels | nindent 4 }}
   {{- end }}
-  name: {{ include "ingress-nginx.controller.fullname" . }}-internal{{ .Values.controller.service.internal.suffix }}
+  name: {{ include "ingress-nginx.controller.fullname" . }}-internal
   namespace: {{ .Release.Namespace }}
 spec:
   type: {{ .Values.controller.service.type }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -37,7 +37,7 @@ metadata:
   {{- if .Values.controller.service.labels }}
     {{- toYaml .Values.controller.service.labels | nindent 4 }}
   {{- end }}
-  name: {{ include "ingress-nginx.controller.fullname" . }}{{ .Values.controller.service.suffix }}
+  name: {{ include "ingress-nginx.controller.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   type: {{ .Values.controller.service.type }}

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -810,9 +810,6 @@
                                 },
                                 "subdomain": {
                                     "type": "string"
-                                },
-                                "suffix": {
-                                    "type": "string"
                                 }
                             }
                         },
@@ -871,9 +868,6 @@
                             "enum": ["None", "ClientIP"]
                         },
                         "subdomain": {
-                            "type": "string"
-                        },
-                        "suffix": {
                             "type": "string"
                         },
                         "targetPorts": {

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -420,13 +420,6 @@ controller:
     configMapKey: ""
   service:
     enabled: true
-
-    # controller.service.suffix
-    # Suffix to add to the LoadBalancer Service name. This is useful for
-    # OpenStack where cloud controller creates and references LBs by the name
-    # and the namespace of the Service.
-    suffix: ""
-
     # -- If enabled is adding an appProtocol option for Kubernetes service. An appProtocol field replacing annotations that were
     # using for setting a backend protocol. Here is an example for AWS: service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
     # It allows choosing the protocol for each backend specified in the Kubernetes service.
@@ -515,13 +508,6 @@ controller:
     internal:
       # -- Enables an additional internal load balancer (besides the external one).
       enabled: false
-
-      # controller.service.internal.suffix
-      # Suffix to add to the LoadBalancer Service name. This is useful for
-      # OpenStack where cloud controller creates and references LBs by the name
-      # and the namespace of the Service.
-      suffix: ""
-
       # -- Annotations are mandatory for the load balancer to come up. Varies with the cloud service.
       annotations: {}
       # loadBalancerIP: ""

--- a/tests/test-values.yaml
+++ b/tests/test-values.yaml
@@ -10,5 +10,4 @@ controller:
       cpu: 100m
       memory: 90Mi
   service:
-    suffix: "-test"
     type: NodePort


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version | ✓ | ✓ |  |
| Existing Ingress resources are reconciled correctly | ✓ | ✓ |  |
| Fresh install | ✓ | ✓ |  |
| Fresh Ingress resources are reconciled correctly | ✓ | ✓ |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
