### PR TITLE
Deployment/DaemonSet: Remove duplicate Prometheus annotations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
     **NOTE:** This is part of our alignment to upstream. Use `controller.extraArgs` instead.
   - Params: Remove `controller.updateIngressStatus`.\
     **NOTE:** This is part of our alignment to upstream. Use `controller.extraArgs` instead.
+- Deployment/DaemonSet: Remove duplicate Prometheus annotations. ([#455](https://github.com/giantswarm/nginx-ingress-controller-app/pull/455))
 
 ## [2.29.0] - 2023-04-03
 

--- a/helm/nginx-ingress-controller-app/templates/controller-daemonset.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-daemonset.yaml
@@ -12,11 +12,8 @@ metadata:
     {{- end }}
   name: {{ include "ingress-nginx.controller.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  annotations:
-    prometheus.io/port: "{{ .Values.controller.metrics.port }}"
-    prometheus.io/scrape: "true"
   {{- if .Values.controller.annotations }}
-    {{ toYaml .Values.controller.annotations | nindent 4 }}
+  annotations: {{ toYaml .Values.controller.annotations | nindent 4 }}
   {{- end }}
 spec:
   selector:

--- a/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-deployment.yaml
@@ -12,11 +12,8 @@ metadata:
     {{- end }}
   name: {{ include "ingress-nginx.controller.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  annotations:
-    prometheus.io/port: "{{ .Values.controller.metrics.port }}"
-    prometheus.io/scrape: "true"
   {{- if .Values.controller.annotations }}
-    {{ toYaml .Values.controller.annotations | nindent 4 }}
+  annotations: {{ toYaml .Values.controller.annotations | nindent 4 }}
   {{- end }}
 spec:
   selector:

--- a/helm/nginx-ingress-controller-app/templates/controller-service-metrics.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-metrics.yaml
@@ -3,11 +3,9 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    giantswarm.io/monitoring-path: /metrics
+    giantswarm.io/monitoring-app-label: {{ .Chart.Name }}
     giantswarm.io/monitoring-port: {{ .Values.controller.metrics.port | quote }}
-    giantswarm.io/monitoring-app-label: {{ .Chart.Name | quote }}
-    prometheus.io/port: {{ .Values.controller.metrics.port | quote }}
-    prometheus.io/scrape: "true"
+    giantswarm.io/monitoring-path: /metrics
   {{- if .Values.controller.metrics.service.annotations }}
     {{ toYaml .Values.controller.metrics.service.annotations | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version | ✓ | ✓ |  |
| Existing Ingress resources are reconciled correctly | ✓ | ✓ |  |
| Fresh install | ✓ | ✓ |  |
| Fresh Ingress resources are reconciled correctly | ✓ | ✓ |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
