### PR TITLE
Values: Remove `configmap` keys matching defaults.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Deployment/DaemonSet: Remove duplicate Prometheus annotations. ([#455](https://github.com/giantswarm/nginx-ingress-controller-app/pull/455))
 - Values: Remove `configmap` keys matching defaults. ([#457](https://github.com/giantswarm/nginx-ingress-controller-app/pull/457))
   - Values: Remove `configmap.error-log-level`.
+  - Values: Remove `configmap.server-name-hash-bucket-size`.
 
 ## [2.29.0] - 2023-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Deployment/DaemonSet: Remove `cluster-autoscaler.kubernetes.io/safe-to-evict` annotation. ([#449](https://github.com/giantswarm/nginx-ingress-controller-app/pull/449))
 - Deployment/DaemonSet: Remove duplicate Prometheus annotations. ([#455](https://github.com/giantswarm/nginx-ingress-controller-app/pull/455))
+- Values: Remove `configmap` keys matching defaults. ([#457](https://github.com/giantswarm/nginx-ingress-controller-app/pull/457))
+  - Values: Remove `configmap.error-log-level`.
 
 ## [2.29.0] - 2023-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Values: Remove `configmap` keys matching defaults. ([#457](https://github.com/giantswarm/nginx-ingress-controller-app/pull/457))
   - Values: Remove `configmap.error-log-level`.
   - Values: Remove `configmap.server-name-hash-bucket-size`.
+  - Values: Remove `configmap.worker-processes`.
 
 ## [2.29.0] - 2023-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Values: Remove `configmap.error-log-level`.
   - Values: Remove `configmap.server-name-hash-bucket-size`.
   - Values: Remove `configmap.worker-processes`.
+  - Values: Remove `configmap.worker-shutdown-timeout`.
 
 ## [2.29.0] - 2023-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Values: Remove `configmap.server-name-hash-bucket-size`.
   - Values: Remove `configmap.worker-processes`.
   - Values: Remove `configmap.worker-shutdown-timeout`.
+  - Values: Remove `configmap.use-forwarded-headers`.
 
 ## [2.29.0] - 2023-04-03
 

--- a/helm/nginx-ingress-controller-app/README.md
+++ b/helm/nginx-ingress-controller-app/README.md
@@ -104,7 +104,6 @@ Please ensure that cert-manager is correctly installed and configured.
 | baseDomain | string | `""` |  |
 | commonLabels | object | `{}` |  |
 | configmap.hsts | string | `"false"` |  |
-| configmap.use-forwarded-headers | string | `"false"` |  |
 | controller.addHeaders | object | `{}` | Will add custom headers before sending response traffic to the client according to: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#add-headers |
 | controller.admissionWebhooks.annotations | object | `{}` |  |
 | controller.admissionWebhooks.certManager.admissionCert.duration | string | `""` |  |

--- a/helm/nginx-ingress-controller-app/README.md
+++ b/helm/nginx-ingress-controller-app/README.md
@@ -105,7 +105,6 @@ Please ensure that cert-manager is correctly installed and configured.
 | commonLabels | object | `{}` |  |
 | configmap.hsts | string | `"false"` |  |
 | configmap.use-forwarded-headers | string | `"false"` |  |
-| configmap.worker-shutdown-timeout | string | `"240s"` |  |
 | controller.addHeaders | object | `{}` | Will add custom headers before sending response traffic to the client according to: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#add-headers |
 | controller.admissionWebhooks.annotations | object | `{}` |  |
 | controller.admissionWebhooks.certManager.admissionCert.duration | string | `""` |  |

--- a/helm/nginx-ingress-controller-app/README.md
+++ b/helm/nginx-ingress-controller-app/README.md
@@ -104,7 +104,6 @@ Please ensure that cert-manager is correctly installed and configured.
 | baseDomain | string | `""` |  |
 | commonLabels | object | `{}` |  |
 | configmap.hsts | string | `"false"` |  |
-| configmap.server-name-hash-bucket-size | string | `"1024"` |  |
 | configmap.use-forwarded-headers | string | `"false"` |  |
 | configmap.worker-processes | string | `"4"` |  |
 | configmap.worker-shutdown-timeout | string | `"240s"` |  |

--- a/helm/nginx-ingress-controller-app/README.md
+++ b/helm/nginx-ingress-controller-app/README.md
@@ -105,7 +105,6 @@ Please ensure that cert-manager is correctly installed and configured.
 | commonLabels | object | `{}` |  |
 | configmap.hsts | string | `"false"` |  |
 | configmap.use-forwarded-headers | string | `"false"` |  |
-| configmap.worker-processes | string | `"4"` |  |
 | configmap.worker-shutdown-timeout | string | `"240s"` |  |
 | controller.addHeaders | object | `{}` | Will add custom headers before sending response traffic to the client according to: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#add-headers |
 | controller.admissionWebhooks.annotations | object | `{}` |  |

--- a/helm/nginx-ingress-controller-app/README.md
+++ b/helm/nginx-ingress-controller-app/README.md
@@ -103,7 +103,6 @@ Please ensure that cert-manager is correctly installed and configured.
 |-----|------|---------|-------------|
 | baseDomain | string | `""` |  |
 | commonLabels | object | `{}` |  |
-| configmap.error-log-level | string | `"notice"` |  |
 | configmap.hsts | string | `"false"` |  |
 | configmap.server-name-hash-bucket-size | string | `"1024"` |  |
 | configmap.use-forwarded-headers | string | `"false"` |  |

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -14,9 +14,6 @@
                 "hsts": {
                     "type": "string"
                 },
-                "server-name-hash-bucket-size": {
-                    "type": "string"
-                },
                 "use-forwarded-headers": {
                     "type": "string"
                 },

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -17,9 +17,6 @@
                 "use-forwarded-headers": {
                     "type": "string"
                 },
-                "worker-processes": {
-                    "type": "string"
-                },
                 "worker-shutdown-timeout": {
                     "type": "string"
                 }

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -13,9 +13,6 @@
             "properties": {
                 "hsts": {
                     "type": "string"
-                },
-                "use-forwarded-headers": {
-                    "type": "string"
                 }
             }
         },

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -11,9 +11,6 @@
         "configmap": {
             "type": "object",
             "properties": {
-                "error-log-level": {
-                    "type": "string"
-                },
                 "hsts": {
                     "type": "string"
                 },

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -16,9 +16,6 @@
                 },
                 "use-forwarded-headers": {
                     "type": "string"
-                },
-                "worker-shutdown-timeout": {
-                    "type": "string"
                 }
             }
         },

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -989,11 +989,6 @@ configmap:
   # See https://github.com/kubernetes/ingress-nginx/issues/549#issuecomment-291894246
   hsts: "false"
 
-  # configmap.server-name-hash-bucket-size
-  # Sets the size of the bucket for the server names hash tables.
-  # Increase hash table size to allow more server names for stability reasons
-  server-name-hash-bucket-size: "1024"
-
   # configmap.worker-processes
   # Sets the number of worker processes.
   worker-processes: "4"

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -989,10 +989,6 @@ configmap:
   # See https://github.com/kubernetes/ingress-nginx/issues/549#issuecomment-291894246
   hsts: "false"
 
-  # configmap.worker-processes
-  # Sets the number of worker processes.
-  worker-processes: "4"
-
   # configmap.worker-shutdown-timeout
   # Maximum amount of time NGINX worker processes should give active connections to drain.
   # This should not be higher than controller.terminationGracePeriodSeconds

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -989,10 +989,6 @@ configmap:
   # See https://github.com/kubernetes/ingress-nginx/issues/549#issuecomment-291894246
   hsts: "false"
 
-  # configmap.use-forwarded-headers
-  # If true, NGINX passes the incoming X-Forwarded-* headers to upstreams.
-  use-forwarded-headers: "false"
-
 # Below are configuration values that you should not overwrite or set yourself.
 
 # image

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -989,11 +989,6 @@ configmap:
   # See https://github.com/kubernetes/ingress-nginx/issues/549#issuecomment-291894246
   hsts: "false"
 
-  # configmap.worker-shutdown-timeout
-  # Maximum amount of time NGINX worker processes should give active connections to drain.
-  # This should not be higher than controller.terminationGracePeriodSeconds
-  worker-shutdown-timeout: "240s"
-
   # configmap.use-forwarded-headers
   # If true, NGINX passes the incoming X-Forwarded-* headers to upstreams.
   use-forwarded-headers: "false"

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -983,12 +983,6 @@ dhParam: ""
 # https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/configmap.md#configmaps
 configmap:
 
-  # configmap.error-log-level
-  # Configures the logging level of errors.
-  # Valid values: debug, info, notice, warn, error, crit, alert, or emerg
-  # References: http://nginx.org/en/docs/ngx_core_module.html#error_log
-  error-log-level: "notice"
-
   # configmap.hsts
   # Enables or disables the HTTP Strict Transport Security (HSTS) header in
   # servers running SSL.


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR removes those keys from `configmap` which already match their default documented in [here](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/).

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version | ✓ | ✓ |  |
| Existing Ingress resources are reconciled correctly | ✓ | ✓ |  |
| Fresh install | ✓ | ✓ |  |
| Fresh Ingress resources are reconciled correctly | ✓ | ✓ |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
