### PR TITLE
Service: Remove deprecated & default annotations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Service: Remove deprecated & default annotations. ([#458](https://github.com/giantswarm/nginx-ingress-controller-app/pull/458))
+
 ### Removed
 
 - Deployment/DaemonSet: Remove `cluster-autoscaler.kubernetes.io/safe-to-evict` annotation. ([#449](https://github.com/giantswarm/nginx-ingress-controller-app/pull/449))

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -7,7 +7,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
   {{- end }}
   {{- if and .Values.controller.service.externalDNS.enabled .Values.baseDomain }}
-    external-dns.alpha.kubernetes.io/hostname: "{{ .Values.controller.service.internal.subdomain }}.{{ .Values.baseDomain }}"
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.controller.service.internal.subdomain }}.{{ .Values.baseDomain }}
     {{- if .Values.controller.service.externalDNS.annotation }}
     {{ .Values.controller.service.externalDNS.annotation }}
     {{- end }}
@@ -15,13 +15,11 @@ metadata:
   {{- if eq .Values.controller.service.type "LoadBalancer" }}
   {{- if or (eq .Values.provider "aws") (eq .Values.provider "capa") }}
     service.beta.kubernetes.io/aws-load-balancer-internal: "true"
-    service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
     {{- if ne (index .Values.configmap "use-proxy-protocol") "false" }}
     service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
     {{- end }}
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
   {{- else if eq .Values.provider "azure" }}
-    service.beta.kubernetes.io/azure-load-balancer-mixed-protocols: "true"
     service.beta.kubernetes.io/azure-load-balancer-internal: "true"
   {{- else if eq .Values.provider "cloud-director" }}
     service.beta.kubernetes.io/vcloud-avi-ssl-no-termination: "true"

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -7,7 +7,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
   {{- end }}
   {{- if and .Values.controller.service.externalDNS.enabled .Values.baseDomain }}
-    external-dns.alpha.kubernetes.io/hostname: "{{ .Values.controller.service.subdomain }}.{{ .Values.baseDomain }}"
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.controller.service.subdomain }}.{{ .Values.baseDomain }}
     {{- if .Values.controller.service.externalDNS.annotation }}
     {{ .Values.controller.service.externalDNS.annotation }}
     {{- end }}
@@ -16,14 +16,12 @@ metadata:
   {{- if or (eq .Values.provider "aws") (eq .Values.provider "capa") }}
     {{- if not .Values.controller.service.public }}
     service.beta.kubernetes.io/aws-load-balancer-internal: "true"
-    service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
     {{- end }}
     {{- if ne (index .Values.configmap "use-proxy-protocol") "false" }}
     service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
     {{- end }}
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
   {{- else if eq .Values.provider "azure" }}
-    service.beta.kubernetes.io/azure-load-balancer-mixed-protocols: "true"
     {{- if not .Values.controller.service.public }}
     service.beta.kubernetes.io/azure-load-balancer-internal: "true"
     {{- end }}


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

`service.beta.kubernetes.io/aws-load-balancer-scheme` defaults to `internal` and only applies to AWS Load Balancer Controller, `service.beta.kubernetes.io/azure-load-balancer-mixed-protocols` has been deprecated long ago.

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version | ✓ | ✓ |  |
| Existing Ingress resources are reconciled correctly | ✓ | ✓ |  |
| Fresh install | ✓ | ✓ |  |
| Fresh Ingress resources are reconciled correctly | ✓ | ✓ |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
