### PR TITLE
Service: Remove default values for `controller.service.nodePorts` & `controller.service.internal.nodePorts`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
     **NOTE:** This is part of our alignment to upstream. Use `controller.extraArgs` instead.
   - Params: Remove `controller.updateIngressStatus`.\
     **NOTE:** This is part of our alignment to upstream. Use `controller.extraArgs` instead.
+- Service: Remove default values for `controller.service.nodePorts` & `controller.service.internal.nodePorts`. ([#461](https://github.com/giantswarm/nginx-ingress-controller-app/pull/461))\
+  **NOTE:** If you are running on our KVM product, please make sure to manually set those keys to their prior values.
 
 ## [2.30.0] - 2023-04-18
 

--- a/helm/nginx-ingress-controller-app/README.md
+++ b/helm/nginx-ingress-controller-app/README.md
@@ -282,8 +282,8 @@ Please ensure that cert-manager is correctly installed and configured.
 | controller.service.internal.enabled | bool | `false` | Enables an additional internal load balancer (besides the external one). |
 | controller.service.internal.externalTrafficPolicy | string | `"Local"` |  |
 | controller.service.internal.loadBalancerSourceRanges | list | `[]` | Restrict access For LoadBalancer service. Defaults to 0.0.0.0/0. |
-| controller.service.internal.nodePorts.http | int | `30012` |  |
-| controller.service.internal.nodePorts.https | int | `30013` |  |
+| controller.service.internal.nodePorts.http | string | `""` |  |
+| controller.service.internal.nodePorts.https | string | `""` |  |
 | controller.service.internal.nodePorts.tcp | object | `{}` |  |
 | controller.service.internal.nodePorts.udp | object | `{}` |  |
 | controller.service.internal.subdomain | string | `"ingress-internal"` |  |
@@ -292,8 +292,8 @@ Please ensure that cert-manager is correctly installed and configured.
 | controller.service.labels | object | `{}` |  |
 | controller.service.loadBalancerIP | string | `""` | Used by cloud providers to connect the resulting `LoadBalancer` to a pre-existing static IP according to https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer |
 | controller.service.loadBalancerSourceRanges | list | `[]` |  |
-| controller.service.nodePorts.http | int | `30010` |  |
-| controller.service.nodePorts.https | int | `30011` |  |
+| controller.service.nodePorts.http | string | `""` |  |
+| controller.service.nodePorts.https | string | `""` |  |
 | controller.service.nodePorts.tcp | object | `{}` |  |
 | controller.service.nodePorts.udp | object | `{}` |  |
 | controller.service.ports.http | int | `80` |  |

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -45,7 +45,7 @@ spec:
   externalTrafficPolicy: {{ .Values.controller.service.internal.externalTrafficPolicy }}
 {{- end }}
   ports:
-  {{- $setNodePorts := (eq .Values.controller.service.type "NodePort") }}
+  {{- $setNodePorts := (or (eq .Values.controller.service.type "NodePort") (eq .Values.controller.service.type "LoadBalancer")) }}
   {{- if .Values.controller.service.enableHttp }}
     - name: http
       port: {{ .Values.controller.service.ports.http }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -71,7 +71,7 @@ spec:
 {{- end }}
 {{- end }}
   ports:
-  {{- $setNodePorts := (eq .Values.controller.service.type "NodePort") }}
+  {{- $setNodePorts := (or (eq .Values.controller.service.type "NodePort") (eq .Values.controller.service.type "LoadBalancer")) }}
   {{- if .Values.controller.service.enableHttp }}
     - name: http
       port: {{ .Values.controller.service.ports.http }}

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -771,10 +771,10 @@
                                     "type": "object",
                                     "properties": {
                                         "http": {
-                                            "type": "integer"
+                                            "type": ["string", "integer"]
                                         },
                                         "https": {
-                                            "type": "integer"
+                                            "type": ["string", "integer"]
                                         },
                                         "tcp": {
                                             "type": "object"
@@ -812,10 +812,10 @@
                             "type": "object",
                             "properties": {
                                 "http": {
-                                    "type": "integer"
+                                    "type": ["string", "integer"]
                                 },
                                 "https": {
-                                    "type": "integer"
+                                    "type": ["string", "integer"]
                                 },
                                 "tcp": {
                                     "type": "object"

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -499,8 +499,8 @@ controller:
     ##   tcp:
     ##     8080: 32808
     nodePorts:
-      http: 30010
-      https: 30011
+      http: ""
+      https: ""
       tcp: {}
       udp: {}
     external:
@@ -530,8 +530,8 @@ controller:
       ##   tcp:
       ##     8080: 31808
       nodePorts:
-        http: 30012
-        https: 30013
+        http: ""
+        https: ""
         tcp: {}
         udp: {}
   # shareProcessNamespace enables process namespace sharing within the pod.

--- a/tests/test-values.yaml
+++ b/tests/test-values.yaml
@@ -11,3 +11,10 @@ controller:
       memory: 90Mi
   service:
     type: NodePort
+    nodePorts:
+      http: 30010
+      https: 30011
+    internal:
+      nodePorts:
+        http: 30012
+        https: 30013


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version | ✓ | ✓ |  |
| Existing Ingress resources are reconciled correctly | ✓ | ✓ |  |
| Fresh install | ✓ | ✓ |  |
| Fresh Ingress resources are reconciled correctly | ✓ | ✓ |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
