### PR TITLE
Params: Remove `controller.disableExternalNameForwarding`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
     **NOTE:** This is part of our alignment to upstream. Use `controller.extraArgs` instead.
 - Service: Remove default values for `controller.service.nodePorts` & `controller.service.internal.nodePorts`. ([#461](https://github.com/giantswarm/nginx-ingress-controller-app/pull/461))\
   **NOTE:** If you are running on our KVM product, please make sure to manually set those keys to their prior values.
+- Params: Remove `controller.disableExternalNameForwarding`. ([#462](https://github.com/giantswarm/nginx-ingress-controller-app/pull/462))\
+  **NOTE:** This is part of our alignment to upstream. Use `controller.extraArgs` instead.
 
 ## [2.30.0] - 2023-04-18
 

--- a/helm/nginx-ingress-controller-app/README.md
+++ b/helm/nginx-ingress-controller-app/README.md
@@ -159,7 +159,6 @@ Please ensure that cert-manager is correctly installed and configured.
 | controller.containerPort | object | `{"http":80,"https":443}` | Configures the ports that the nginx-controller listens on |
 | controller.customTemplate.configMapKey | string | `""` |  |
 | controller.customTemplate.configMapName | string | `""` |  |
-| controller.disableExternalNameForwarding | bool | `true` | disable-svc-external-name flag |
 | controller.dnsConfig | object | `{}` | Optionally customize the pod dnsConfig. |
 | controller.dnsPolicy | string | `"ClusterFirst"` | Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'. By default, while using host network, name resolution uses the host's DNS. If you wish nginx-controller to keep resolving names inside the k8s network, use ClusterFirstWithHostNet. |
 | controller.electionID | string | `""` | Election ID to use for status update, by default it uses the controller name combined with a suffix of 'leader' |

--- a/helm/nginx-ingress-controller-app/templates/_params.tpl
+++ b/helm/nginx-ingress-controller-app/templates/_params.tpl
@@ -62,7 +62,4 @@
 - --{{ $key }}={{ $value }}
 {{- end }}
 {{- end }}
-{{- if .Values.controller.disableExternalNameForwarding }}
-- --disable-svc-external-name
-{{- end }}
 {{- end -}}

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -287,9 +287,6 @@
                         }
                     }
                 },
-                "disableExternalNameForwarding": {
-                    "type": "boolean"
-                },
                 "dnsConfig": {
                     "type": "object"
                 },

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -168,10 +168,6 @@ controller:
   #         key: FOO
   #         name: secret-resource
 
-  # Enable or disable forwarding to ExternalName Services through
-  # --disable-svc-external-name flag
-  disableExternalNameForwarding: true
-
   # -- Use a `DaemonSet` or `Deployment`
   kind: Deployment
   # -- Annotations to be added to the controller Deployment or DaemonSet


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version | ✓ | ✓ |  |
| Existing Ingress resources are reconciled correctly | ✓ | ✓ |  |
| Fresh install | ✓ | ✓ |  |
| Fresh Ingress resources are reconciled correctly | ✓ | ✓ |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
