### PR TITLE
Values: Deprecate `configmap`, use `controller.config` instead.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Helpers: Align labels to upstream. ([#450](https://github.com/giantswarm/nginx-ingress-controller-app/pull/450))
 - Values: Align CPU & memory requests to actual needs. ([#453](https://github.com/giantswarm/nginx-ingress-controller-app/pull/453))
+- Values: Deprecate `configmap`, use `controller.config` instead. ([#463](https://github.com/giantswarm/nginx-ingress-controller-app/pull/463))
 
 ### Removed
 

--- a/helm/nginx-ingress-controller-app/README.md
+++ b/helm/nginx-ingress-controller-app/README.md
@@ -103,7 +103,7 @@ Please ensure that cert-manager is correctly installed and configured.
 |-----|------|---------|-------------|
 | baseDomain | string | `""` |  |
 | commonLabels | object | `{}` |  |
-| configmap.hsts | string | `"false"` |  |
+| configmap | object | `{}` | Deprecated, use `controller.config` instead. |
 | controller.addHeaders | object | `{}` | Will add custom headers before sending response traffic to the client according to: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#add-headers |
 | controller.admissionWebhooks.annotations | object | `{}` |  |
 | controller.admissionWebhooks.certManager.admissionCert.duration | string | `""` |  |
@@ -152,7 +152,8 @@ Please ensure that cert-manager is correctly installed and configured.
 | controller.autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | controller.autoscaling.targetMemoryUtilizationPercentage | int | `80` |  |
 | controller.autoscalingTemplate | list | `[]` |  |
-| controller.config | object | `{}` | Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/ |
+| controller.config | object | `{"hsts":"false"}` | Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/ |
+| controller.config.hsts | string | `"false"` | Enable HSTS or not. Disabled by default due to possible serious consequences. Ref: https://github.com/kubernetes/ingress-nginx/issues/549 |
 | controller.configAnnotations | object | `{}` | Annotations to be added to the controller config configuration configmap. |
 | controller.configMapNamespace | string | `""` | Allows customization of the configmap / nginx-configmap namespace; defaults to $(POD_NAMESPACE) |
 | controller.containerName | string | `"controller"` | Configures the controller container name |

--- a/helm/nginx-ingress-controller-app/templates/controller-configmap.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-configmap.yaml
@@ -23,10 +23,9 @@ data:
 {{- if .Values.dhParam }}
   ssl-dh-param: {{ .Release.Namespace }}/{{ include "ingress-nginx.controller.fullname" . }}
 {{- end }}
-{{- range $key, $value := .Values.controller.config }}
+{{- range $key, $value := merge .Values.controller.config .Values.configmap }}
   {{- $key | nindent 2 }}: {{ $value | quote }}
 {{- end }}
-{{- toYaml .Values.configmap | trim | nindent 2 }}
-{{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (not (index .Values.configmap "use-proxy-protocol")) }}
+{{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (not (index .Values.controller.config "use-proxy-protocol")) }}
   use-proxy-protocol: "true"
 {{- end }}

--- a/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service-internal.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- if eq .Values.controller.service.type "LoadBalancer" }}
   {{- if or (eq .Values.provider "aws") (eq .Values.provider "capa") }}
     service.beta.kubernetes.io/aws-load-balancer-internal: "true"
-    {{- if ne (index .Values.configmap "use-proxy-protocol") "false" }}
+    {{- if ne (index (merge .Values.controller.config .Values.configmap) "use-proxy-protocol") "false" }}
     service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
     {{- end }}
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"

--- a/helm/nginx-ingress-controller-app/templates/controller-service.yaml
+++ b/helm/nginx-ingress-controller-app/templates/controller-service.yaml
@@ -17,7 +17,7 @@ metadata:
     {{- if not .Values.controller.service.public }}
     service.beta.kubernetes.io/aws-load-balancer-internal: "true"
     {{- end }}
-    {{- if ne (index .Values.configmap "use-proxy-protocol") "false" }}
+    {{- if ne (index (merge .Values.controller.config .Values.configmap) "use-proxy-protocol") "false" }}
     service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
     {{- end }}
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"

--- a/helm/nginx-ingress-controller-app/values.schema.json
+++ b/helm/nginx-ingress-controller-app/values.schema.json
@@ -9,12 +9,7 @@
             "type": "object"
         },
         "configmap": {
-            "type": "object",
-            "properties": {
-                "hsts": {
-                    "type": "string"
-                }
-            }
+            "type": "object"
         },
         "controller": {
             "type": "object",

--- a/helm/nginx-ingress-controller-app/values.yaml
+++ b/helm/nginx-ingress-controller-app/values.yaml
@@ -38,7 +38,10 @@ controller:
     http: 80
     https: 443
   # -- Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
-  config: {}
+  config:
+    # -- Enable HSTS or not. Disabled by default due to possible serious consequences.
+    # Ref: https://github.com/kubernetes/ingress-nginx/issues/549
+    hsts: "false"
   # -- Annotations to be added to the controller config configuration configmap.
   configAnnotations: {}
   # -- Will add custom headers before sending traffic to backends according to https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/custom-headers
@@ -940,17 +943,8 @@ portNamePrefix: ""
 ## Ref: https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/ssl-dh-param
 dhParam: ""
 
-# These values get applied directly to a configmap which configures the
-# nginx-ingress-controller
-# For all the nginx configmap config options see:
-# https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/configmap.md#configmaps
-configmap:
-
-  # configmap.hsts
-  # Enables or disables the HTTP Strict Transport Security (HSTS) header in
-  # servers running SSL.
-  # See https://github.com/kubernetes/ingress-nginx/issues/549#issuecomment-291894246
-  hsts: "false"
+# -- Deprecated, use `controller.config` instead.
+configmap: {}
 
 # Below are configuration values that you should not overwrite or set yourself.
 


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

### Tests on workload clusters (not always required)

For changes in the chart, chart templates, and ingress controller container images, I executed the following tests
to verify them working in live enviromnents:

| Test / Provider | AWS | Azure | KVM |
| --- | --- | --- | --- |
| Upgrade from previous version | ✓ | ✓ |  |
| Existing Ingress resources are reconciled correctly | ✓ | ✓ |  |
| Fresh install | ✓ | ✓ |  |
| Fresh Ingress resources are reconciled correctly | ✓ | ✓ |  |

Testing was done using `hello-world-app`.

Hint for KVM:

```
kubectl port-forward -n kube-system svc/nginx-ingress-controller-app 8080:80
ingress_domain=host.configured.in.ingress; curl --connect-to "$ingress_domain:80:127.0.0.1:8080" "http://$ingress_domain" -v
```
