### PR TITLE
Updated E2E tests to use apptest-framework v1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Updated E2E tests to use apptest-framework v1.14.0
+
 ## [4.0.3] - 2025-07-17
 
 ### Changed

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -4,7 +4,7 @@ go 1.24.2
 
 require (
 	github.com/giantswarm/apiextensions-application v0.6.2
-	github.com/giantswarm/apptest-framework v1.13.0
+	github.com/giantswarm/apptest-framework v1.14.0
 	github.com/giantswarm/clustertest v1.37.0
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
@@ -45,7 +45,7 @@ require (
 	github.com/fluxcd/pkg/apis/meta v1.12.0 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.8.0 // indirect
-	github.com/giantswarm/cluster-standup-teardown v1.31.0 // indirect
+	github.com/giantswarm/cluster-standup-teardown v1.33.3 // indirect
 	github.com/giantswarm/k8smetadata v0.25.0 // indirect
 	github.com/giantswarm/kubectl-gs/v2 v2.57.0 // indirect
 	github.com/giantswarm/microerror v0.4.1 // indirect
@@ -125,8 +125,6 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.35.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.35.0 // indirect
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -102,10 +102,10 @@ github.com/fxamacker/cbor/v2 v2.8.0 h1:fFtUGXUzXPHTIUdne5+zzMPTfffl3RD5qYnkY40vt
 github.com/fxamacker/cbor/v2 v2.8.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt3ztTo25+V63oDVlFwDpNg=
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
-github.com/giantswarm/apptest-framework v1.13.0 h1:pkZntlpL715l+PhuljwSLSD7tqJ4yse46a+P7mDFfr8=
-github.com/giantswarm/apptest-framework v1.13.0/go.mod h1:v9dGj7WPPUPYSOSUGKqYqYiSQ1CfBrQuRLs27oSqXBo=
-github.com/giantswarm/cluster-standup-teardown v1.31.0 h1:9fLk/m/qjOS7zO1a25qgszBLYewdMmEe6R8DIo+7Obs=
-github.com/giantswarm/cluster-standup-teardown v1.31.0/go.mod h1:f6sOC7WXE7cgkgttKvwCqPm6NJ4KzIxKrpe0WfDutn4=
+github.com/giantswarm/apptest-framework v1.14.0 h1:mhUmSI9mi8/LsImvuktCbdVQkHsteRzmqBnpY2wGwNc=
+github.com/giantswarm/apptest-framework v1.14.0/go.mod h1:P1ERxb0tebFPNFSDV+8WTufZlsexl7P8aZc7Az2DJkU=
+github.com/giantswarm/cluster-standup-teardown v1.33.3 h1:aab290cH9QTsizLOSiXYr52s4zlMiNzcPgTkSnFm2Ks=
+github.com/giantswarm/cluster-standup-teardown v1.33.3/go.mod h1:utekr4l2AuWQMxiB0fC6AhLRWfxw9eyp++LZjMvVERQ=
 github.com/giantswarm/clustertest v1.37.0 h1:wW4Q2pltqg3iMoDsioM6A3F4BrTrqXfCgfNMaIObHro=
 github.com/giantswarm/clustertest v1.37.0/go.mod h1:rx91Vuci65WgYDJmPn9JP1oA8pXrfAzGvK7Pymj/UiA=
 github.com/giantswarm/k8smetadata v0.25.0 h1:6mKmmm4xHPuBvxDMAkIhU5oj6KJkJSaR2s5esIsnHs4=

--- a/tests/e2e/suites/auth-bundle/basic_suite_test.go
+++ b/tests/e2e/suites/auth-bundle/basic_suite_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/giantswarm/apptest-framework/pkg/config"
 	"github.com/giantswarm/apptest-framework/pkg/state"
 	"github.com/giantswarm/apptest-framework/pkg/suite"
 	"github.com/giantswarm/clustertest/pkg/logger"
@@ -20,7 +19,7 @@ const (
 )
 
 func TestBasic(t *testing.T) {
-	suite.New(config.MustLoad("../../config.yaml")).
+	suite.New().
 		InAppBundle("auth-bundle").
 		WithInstallNamespace("kube-system").
 		WithIsUpgrade(isUpgrade).

--- a/tests/e2e/suites/basic/basic_suite_test.go
+++ b/tests/e2e/suites/basic/basic_suite_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/giantswarm/apptest-framework/pkg/config"
 	"github.com/giantswarm/apptest-framework/pkg/state"
 	"github.com/giantswarm/apptest-framework/pkg/suite"
 
@@ -27,7 +26,7 @@ func TestBasic(t *testing.T) {
 		appReadyTimeout  = 10 * time.Minute
 		appReadyInterval = 5 * time.Second
 	)
-	suite.New(config.MustLoad("../../config.yaml")).
+	suite.New().
 		WithInstallNamespace("kube-system").
 		WithIsUpgrade(isUpgrade).
 		WithValuesFile("./values.yaml").


### PR DESCRIPTION
<!--
@team-cabbage will automatically be requested for review once this PR has been submitted.
-->

This PR:

- Updated E2E tests to use apptest-framework v1.14.0

---

## Checklist

- [x] I added a CHANGELOG entry
- [x] I ran E2E tests in the CI pipelines

Add the following comment to trigger the E2E tests:

/run app-test-suites
